### PR TITLE
Fix dealing with Windows filepaths

### DIFF
--- a/cmd/microservice/git-test.go
+++ b/cmd/microservice/git-test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	gitStorage "github.com/dolittle-entropy/platform-api/pkg/platform/storage/git"
@@ -43,7 +44,7 @@ var gitTestCMD = &cobra.Command{
 		}
 		microserviceID := "test"
 		data := []byte(`hi 1`)
-		filename := fmt.Sprintf("%s/ms_%s.json", dir, microserviceID)
+		filename := filepath.Join(dir, fmt.Sprintf("ms_%s.json", microserviceID))
 		err = ioutil.WriteFile(filename, data, 0644)
 		if err != nil {
 			fmt.Println("writeFile")

--- a/pkg/platform/storage/git/application.go
+++ b/pkg/platform/storage/git/application.go
@@ -126,7 +126,7 @@ func (s *GitStorage) GetApplications(tenantID string) ([]platform.HttpResponseAp
 	for _, applicationID := range applicationIDs {
 		application, err := s.GetApplication(tenantID, applicationID)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println("Skipping application for tenant", tenantID, "with ID", applicationID, "because it failed to load:", err)
 			continue
 		}
 		applications = append(applications, application)

--- a/pkg/platform/storage/git/application.go
+++ b/pkg/platform/storage/git/application.go
@@ -34,7 +34,6 @@ func (s *GitStorage) SaveApplication(application platform.HttpResponseApplicatio
 		return err
 	}
 
-	// filename := fmt.Sprintf("%s/application.json", dir)
 	filename := filepath.Join(dir, "application.json")
 	err = ioutil.WriteFile(filename, data, 0644)
 	if err != nil {
@@ -100,21 +99,13 @@ func (s *GitStorage) GetApplication(tenantID string, applicationID string) (plat
 func (s *GitStorage) GetApplications(tenantID string) ([]platform.HttpResponseApplication, error) {
 	applicationIDs := []string{}
 
-	// TODO change
-	rootDirectory := s.Directory + "/"
 	// TODO change to fs when gone to 1.16
-	err := filepath.Walk(rootDirectory, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(s.Directory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
 			return err
 		}
 
-		// TODO come back to this
-		//if info.IsDir() {
-		//	fmt.Printf("skipping a dir without errors: %+v \n", info.Name())
-		//	return filepath.SkipDir
-		//}
-		// /tmp/dolittle-k8s/453e04a7-4f9d-42f2-b36c-d51fa2c83fa3/11b6cf47-5d9f-438f-8116-0d9828654657/application.json
 		if info.Name() != "application.json" {
 			return nil
 		}
@@ -126,7 +117,6 @@ func (s *GitStorage) GetApplications(tenantID string) ([]platform.HttpResponseAp
 		applicationIDs = append(applicationIDs, applicationID)
 		return nil
 	})
-	fmt.Println(applicationIDs)
 	applications := make([]platform.HttpResponseApplication, 0)
 
 	if err != nil {

--- a/pkg/platform/storage/git/microservice.go
+++ b/pkg/platform/storage/git/microservice.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *GitStorage) GetMicroserviceDirectory(tenantID string, applicationID string, environment string) string {
-	return fmt.Sprintf("%s/%s/%s/%s", s.Directory, tenantID, applicationID, strings.ToLower(environment))
+	return filepath.Join(s.Directory, tenantID, applicationID, strings.ToLower(environment))
 }
 
 func (s *GitStorage) DeleteMicroservice(tenantID string, applicationID string, environment string, microserviceID string) error {
@@ -23,7 +23,7 @@ func (s *GitStorage) DeleteMicroservice(tenantID string, applicationID string, e
 	}
 
 	dir := s.GetMicroserviceDirectory(tenantID, applicationID, environment)
-	filename := fmt.Sprintf("%s/ms_%s.json", dir, microserviceID)
+	filename := filepath.Join(dir, fmt.Sprintf("ms_%s.json", microserviceID))
 	err = os.Remove(filename)
 	if err != nil {
 		fmt.Println(err)
@@ -72,7 +72,7 @@ func (s *GitStorage) SaveMicroservice(tenantID string, applicationID string, env
 		return err
 	}
 
-	filename := fmt.Sprintf("%s/ms_%s.json", dir, microserviceID)
+	filename := filepath.Join(dir, fmt.Sprintf("ms_%s.json", microserviceID))
 	err = ioutil.WriteFile(filename, storageBytes, 0644)
 	if err != nil {
 		fmt.Println("writeFile")
@@ -107,7 +107,7 @@ func (s *GitStorage) SaveMicroservice(tenantID string, applicationID string, env
 
 func (s *GitStorage) GetMicroservice(tenantID string, applicationID string, environment string, microserviceID string) ([]byte, error) {
 	dir := s.GetMicroserviceDirectory(tenantID, applicationID, environment)
-	filename := fmt.Sprintf("%s/ms_%s.json", dir, microserviceID)
+	filename := filepath.Join(dir, fmt.Sprintf("ms_%s.json", microserviceID))
 	return ioutil.ReadFile(filename)
 }
 

--- a/pkg/platform/storage/git/studio.go
+++ b/pkg/platform/storage/git/studio.go
@@ -2,8 +2,8 @@ package git
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
+	"path/filepath"
 
 	"github.com/dolittle-entropy/platform-api/pkg/platform"
 	"github.com/sirupsen/logrus"
@@ -11,14 +11,14 @@ import (
 
 func (s *GitStorage) SaveStudioConfig(tenantID string, config platform.StudioConfig) error {
 	dir := s.GetTenantDirectory(tenantID)
-	filename := fmt.Sprintf("%s/studio.json", dir)
+	filename := filepath.Join(dir, "studio.json")
 	data, _ := json.MarshalIndent(config, "", "  ")
 	return ioutil.WriteFile(filename, data, 0644)
 }
 
 func (s *GitStorage) GetStudioConfig(tenantID string) (platform.StudioConfig, error) {
 	dir := s.GetTenantDirectory(tenantID)
-	filename := fmt.Sprintf("%s/studio.json", dir)
+	filename := filepath.Join(dir, "studio.json")
 	b, err := ioutil.ReadFile(filename)
 
 	var config platform.StudioConfig

--- a/pkg/platform/storage/git/tenant.go
+++ b/pkg/platform/storage/git/tenant.go
@@ -1,9 +1,9 @@
 package git
 
 import (
-	"fmt"
+	"path/filepath"
 )
 
 func (s *GitStorage) GetTenantDirectory(tenantID string) string {
-	return fmt.Sprintf("%s/%s", s.Directory, tenantID)
+	return filepath.Join(s.Directory, tenantID)
 }

--- a/pkg/platform/storage/git/terraform.go
+++ b/pkg/platform/storage/git/terraform.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/dolittle-entropy/platform-api/pkg/platform"
@@ -29,7 +30,7 @@ func (s *GitStorage) SaveTerraformApplication(applicaiton platform.TerraformAppl
 		return err
 	}
 
-	filename := fmt.Sprintf("%s/terraform.json", dir)
+	filename := filepath.Join(dir, "terraform.json")
 	err = ioutil.WriteFile(filename, data, 0644)
 	if err != nil {
 		fmt.Println("writeFile")
@@ -63,7 +64,7 @@ func (s *GitStorage) SaveTerraformApplication(applicaiton platform.TerraformAppl
 
 func (s *GitStorage) GetTerraformApplication(tenantID string, applicationID string) (platform.TerraformApplication, error) {
 	dir := s.GetApplicationDirectory(tenantID, applicationID)
-	filename := fmt.Sprintf("%s/terraform.json", dir)
+	filename := filepath.Join(dir, "terraform.json")
 	b, err := ioutil.ReadFile(filename)
 
 	var application platform.TerraformApplication
@@ -95,7 +96,7 @@ func (s *GitStorage) SaveTerraformTenant(tenant platform.TerraformCustomer) erro
 		return err
 	}
 
-	filename := fmt.Sprintf("%s/tenant.json", dir)
+	filename := filepath.Join(dir, "tenant.json")
 	err = ioutil.WriteFile(filename, data, 0644)
 	if err != nil {
 		fmt.Println("writeFile")
@@ -129,7 +130,7 @@ func (s *GitStorage) SaveTerraformTenant(tenant platform.TerraformCustomer) erro
 
 func (s *GitStorage) GetTerraformTenant(tenantID string) (platform.TerraformCustomer, error) {
 	dir := s.GetTenantDirectory(tenantID)
-	filename := fmt.Sprintf("%s/tenant.json", dir)
+	filename := filepath.Join(dir, "tenant.json")
 	b, err := ioutil.ReadFile(filename)
 
 	var tenant platform.TerraformCustomer


### PR DESCRIPTION
## Summary

Fixes the filepath code to also work with Windows.

### Fixed

- Fixes the code to also understand Windows style path delimiters instead of just *nix paths when reading the repo.
