### PR TITLE
Change git storage applications structure 

### DIFF
--- a/cmd/microservice/build-applications.go
+++ b/cmd/microservice/build-applications.go
@@ -88,7 +88,9 @@ func extractApplications(ctx context.Context, client *kubernetes.Clientset) []pl
 	applications := make([]platform.HttpResponseApplication, 0)
 
 	for _, ns := range getNamespaces(ctx, client) {
-		// Creates a single application for a namespace(?)
+		if !strings.HasPrefix(ns.GetObjectMeta().GetName(), "application-") {
+			continue
+		}
 		applications = append(applications, getApplicationFromK8s(ctx, client, ns))
 	}
 

--- a/cmd/microservice/build-applications.go
+++ b/cmd/microservice/build-applications.go
@@ -242,7 +242,7 @@ func environmentAlreadyInApplication(environments []platform.HttpInputEnvironmen
 		return item.Name == environmentName
 	})
 
-	if index != -1 {
+	if index == -1 {
 		return false, index
 	}
 	return true, index

--- a/cmd/microservice/build-applications.go
+++ b/cmd/microservice/build-applications.go
@@ -162,7 +162,7 @@ func createOrGetEnvironment(ctx context.Context, client *kubernetes.Clientset, d
 func getTenants(ctx context.Context, client *kubernetes.Clientset, namespace, environmentName string) []platform.TenantId {
 	tenants := make([]platform.TenantId, 0)
 
-	for tenantStr, _ := range getTenantsFromConfigmap(ctx, client, namespace, environmentName) {
+	for tenantStr := range getTenantsFromConfigmap(ctx, client, namespace, environmentName) {
 		tenants = append(tenants, platform.TenantId(tenantStr))
 	}
 	return tenants

--- a/cmd/microservice/build-applications.go
+++ b/cmd/microservice/build-applications.go
@@ -2,7 +2,10 @@ package microservice
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/dolittle-entropy/platform-api/pkg/platform"
 	"github.com/dolittle-entropy/platform-api/pkg/platform/storage"
@@ -12,7 +15,9 @@ import (
 	"github.com/thoas/go-funk"
 	appsV1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	netV1 "k8s.io/api/networking/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -59,6 +64,7 @@ var buildApplicationsCMD = &cobra.Command{
 	},
 }
 
+// SaveApplications saves the Applications
 func SaveApplications(repo storage.Repo, applications []platform.HttpResponseApplication) error {
 	for _, application := range applications {
 		studioConfig, _ := repo.GetStudioConfig(application.TenantID)
@@ -80,22 +86,26 @@ func SaveApplications(repo storage.Repo, applications []platform.HttpResponseApp
 
 func extractApplications(ctx context.Context, client *kubernetes.Clientset) []platform.HttpResponseApplication {
 	applications := make([]platform.HttpResponseApplication, 0)
-	namespaces, err := client.CoreV1().Namespaces().List(ctx, metaV1.ListOptions{})
-	if err != nil {
-		panic(err.Error())
-	}
 
-	for _, ns := range namespaces.Items {
-		// Unique the environments
-		applications = append(applications, createApplicationFromK8s(ctx, client, ns))
+	for _, ns := range getNamespaces(ctx, client) {
+		// Creates a single application for a namespace(?)
+		applications = append(applications, getApplicationFromK8s(ctx, client, ns))
 	}
 
 	return applications
 }
 
-func createApplicationFromK8s(ctx context.Context, client *kubernetes.Clientset, namespace v1.Namespace) platform.HttpResponseApplication {
+func getNamespaces(ctx context.Context, client *kubernetes.Clientset) []v1.Namespace {
+	namespacesList, err := client.CoreV1().Namespaces().List(ctx, metaV1.ListOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+	return namespacesList.Items
+}
+
+func getApplicationFromK8s(ctx context.Context, client *kubernetes.Clientset, namespace v1.Namespace) platform.HttpResponseApplication {
 	application := createBasicApplicationStructureFromMetadata(client, namespace)
-	addEnvironmentsFromK8sInto(&application, ctx, client, namespace, application.TenantID, application.ID)
+	addEnvironmentsFromK8sInto(&application, ctx, client, namespace.GetObjectMeta().GetName())
 	return application
 }
 
@@ -114,18 +124,14 @@ func createBasicApplicationStructureFromMetadata(client *kubernetes.Clientset, n
 	}
 }
 
-func addEnvironmentsFromK8sInto(application *platform.HttpResponseApplication, ctx context.Context, client *kubernetes.Clientset, namespace v1.Namespace, tenantID, applicationID string) {
-	namespaceName := namespace.GetObjectMeta().GetName()
+func addEnvironmentsFromK8sInto(application *platform.HttpResponseApplication, ctx context.Context, client *kubernetes.Clientset, namespaceName string) {
 	for _, deployment := range getDeployments(ctx, client, namespaceName) {
 		if !deploymentHasReqiredMetadata(deployment) {
 			continue
 		}
 
-		environment := createEnvironmentFromK8s(deployment, tenantID, applicationID)
-
-		if environmentAlreadyInApplication(application.Environments, environment.Name) {
-			continue
-		}
+		environment := createOrGetEnvironment(ctx, client, deployment, namespaceName, *application)
+		addIngressesIntoEnvironment(&environment, ctx, client, namespaceName, deployment)
 
 		application.Environments = append(application.Environments, environment)
 	}
@@ -139,13 +145,83 @@ func getDeployments(ctx context.Context, client *kubernetes.Clientset, namespace
 	return deploymentList.Items
 }
 
-func createEnvironmentFromK8s(deployment appsV1.Deployment, tenantID, applicationID string) platform.HttpInputEnvironment {
+func createOrGetEnvironment(ctx context.Context, client *kubernetes.Clientset, deployment appsV1.Deployment, namespace string, application platform.HttpResponseApplication) platform.HttpInputEnvironment {
+	environmentName := deployment.ObjectMeta.Labels["environment"]
+	environmentExists, i := environmentAlreadyInApplication(application.Environments, environmentName)
+	if environmentExists {
+		return application.Environments[i]
+	}
 	return platform.HttpInputEnvironment{
-		Name:          deployment.ObjectMeta.Labels["environment"],
-		TenantID:      tenantID,
-		ApplicationID: applicationID,
+		Name:          environmentName,
+		TenantID:      application.TenantID,
+		ApplicationID: application.ID,
+		Tenants:       getTenants(ctx, client, namespace, environmentName),
+		Ingresses:     make(map[platform.TenantId]platform.EnvironmentIngress),
 	}
 }
+
+func getTenants(ctx context.Context, client *kubernetes.Clientset, namespace, environmentName string) []platform.TenantId {
+	tenants := make([]platform.TenantId, 0)
+
+	for tenantStr, _ := range getTenantsFromConfigmap(ctx, client, namespace, environmentName) {
+		tenants = append(tenants, platform.TenantId(tenantStr))
+	}
+	return tenants
+}
+
+func addIngressesIntoEnvironment(environment *platform.HttpInputEnvironment, ctx context.Context, client *kubernetes.Clientset, namespace string, deployment appsV1.Deployment) map[platform.TenantId]platform.EnvironmentIngress {
+	ingresses := environment.Ingresses
+	for _, ingress := range getIngresses(ctx, client, namespace, deployment) {
+		if len(ingress.Spec.TLS) > 0 {
+			// Assume that there is only one Rule, or that only the top one counts
+			// Note that this will override ingresses for tenants, not a problem if they are the same, but confusing if there are different configs
+			ingresses[getTenantFromIngress(ingress)] = extractEnvironmentIngressFromIngressRule(ingress.Spec.Rules[0])
+		}
+	}
+	return ingresses
+}
+
+func extractEnvironmentIngressFromIngressRule(rule netV1.IngressRule) platform.EnvironmentIngress {
+	host := rule.Host
+	domainPrefix := strings.ReplaceAll(host, ".dolittle.cloud", "")
+
+	// Note that this will override ingresses for tenants, not a problem if they are the same, but confusing if there are different configs
+	return platform.EnvironmentIngress{
+		Host:         host,
+		DomainPrefix: domainPrefix,
+	}
+}
+func getTenantFromIngress(ingress netV1.Ingress) platform.TenantId {
+	tenantHeaderAnnotation := ingress.GetObjectMeta().GetAnnotations()["nginx.ingress.kubernetes.io/configuration-snippet"]
+	tenantID := strings.ReplaceAll(tenantHeaderAnnotation, "proxy_set_header Tenant-ID", "")
+	tenantID = strings.ReplaceAll(tenantID, "\"", "")
+	return platform.TenantId(strings.TrimSpace(tenantID))
+}
+
+func getIngresses(ctx context.Context, client *kubernetes.Clientset, namespace string, deployment appsV1.Deployment) []netV1.Ingress {
+	ingresses, err := client.NetworkingV1().Ingresses(namespace).List(ctx, metaV1.ListOptions{
+		LabelSelector: labels.FormatLabels(deployment.Labels),
+	})
+	if err != nil {
+		panic(err.Error())
+	}
+	return ingresses.Items
+}
+
+func getTenantsFromConfigmap(ctx context.Context, client *kubernetes.Clientset, namespace, environmentName string) map[string]interface{} {
+	tenantsConfig, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, fmt.Sprintf("%s-tenants", strings.ToLower(environmentName)), metaV1.GetOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+	tenantsJson := tenantsConfig.Data["tenants.json"]
+	tenants := make(map[string]interface{})
+	err = json.Unmarshal([]byte(tenantsJson), &tenants)
+	if err != nil {
+		panic(err.Error())
+	}
+	return tenants
+}
+
 func deploymentHasReqiredMetadata(deployment appsV1.Deployment) bool {
 	_, ok := deployment.ObjectMeta.Annotations["dolittle.io/tenant-id"]
 	if !ok {
@@ -163,16 +239,18 @@ func deploymentHasReqiredMetadata(deployment appsV1.Deployment) bool {
 	}
 	return true
 }
-func environmentAlreadyInApplication(environments []platform.HttpInputEnvironment, environmentName string) bool {
+
+func environmentAlreadyInApplication(environments []platform.HttpInputEnvironment, environmentName string) (bool, int) {
 	index := funk.IndexOf(environments, func(item platform.HttpInputEnvironment) bool {
 		return item.Name == environmentName
 	})
 
 	if index != -1 {
-		return false
+		return false, index
 	}
-	return true
+	return true, index
 }
+
 func init() {
 	RootCmd.AddCommand(buildApplicationsCMD)
 	buildApplicationsCMD.Flags().String("kube-config", "", "FullPath to kubeconfig")

--- a/cmd/microservice/build-applications.go
+++ b/cmd/microservice/build-applications.go
@@ -126,7 +126,7 @@ func createBasicApplicationStructureFromMetadata(client *kubernetes.Clientset, n
 
 func addEnvironmentsFromK8sInto(application *platform.HttpResponseApplication, ctx context.Context, client *kubernetes.Clientset, namespaceName string) {
 	for _, deployment := range getDeployments(ctx, client, namespaceName) {
-		if !deploymentHasReqiredMetadata(deployment) {
+		if !deploymentHasRequiredMetadata(deployment) {
 			continue
 		}
 
@@ -222,7 +222,7 @@ func getTenantsFromConfigmap(ctx context.Context, client *kubernetes.Clientset, 
 	return tenants
 }
 
-func deploymentHasReqiredMetadata(deployment appsV1.Deployment) bool {
+func deploymentHasRequiredMetadata(deployment appsV1.Deployment) bool {
 	_, ok := deployment.ObjectMeta.Annotations["dolittle.io/tenant-id"]
 	if !ok {
 		return false

--- a/cmd/microservice/build-applications.go
+++ b/cmd/microservice/build-applications.go
@@ -115,12 +115,9 @@ func createBasicApplicationStructureFromMetadata(client *kubernetes.Clientset, n
 	annotationsMap := namespace.GetObjectMeta().GetAnnotations()
 	labelMap := namespace.GetObjectMeta().GetLabels()
 
-	applicationID := annotationsMap["dolittle.io/application-id"]
-	tenantID := annotationsMap["dolittle.io/tenant-id"]
-
 	return platform.HttpResponseApplication{
-		TenantID:     tenantID,
-		ID:           applicationID,
+		TenantID:     annotationsMap["dolittle.io/tenant-id"],
+		ID:           annotationsMap["dolittle.io/application-id"],
 		Name:         labelMap["application"],
 		Environments: make([]platform.HttpInputEnvironment, 0),
 	}
@@ -225,20 +222,18 @@ func getTenantsFromConfigmap(ctx context.Context, client *kubernetes.Clientset, 
 }
 
 func deploymentHasRequiredMetadata(deployment appsV1.Deployment) bool {
-	_, ok := deployment.ObjectMeta.Annotations["dolittle.io/tenant-id"]
-	if !ok {
+	if _, ok := deployment.ObjectMeta.Annotations["dolittle.io/tenant-id"]; !ok {
 		return false
 	}
 
-	_, ok = deployment.ObjectMeta.Annotations["dolittle.io/application-id"]
-	if !ok {
+	if _, ok := deployment.ObjectMeta.Annotations["dolittle.io/application-id"]; !ok {
 		return false
 	}
 
-	_, ok = deployment.ObjectMeta.Labels["application"]
-	if !ok {
+	if _, ok := deployment.ObjectMeta.Labels["application"]; !ok {
 		return false
 	}
+
 	return true
 }
 

--- a/cmd/microservice/build-applications.go
+++ b/cmd/microservice/build-applications.go
@@ -156,7 +156,7 @@ func createOrGetEnvironment(ctx context.Context, client *kubernetes.Clientset, d
 		TenantID:      application.TenantID,
 		ApplicationID: application.ID,
 		Tenants:       getTenants(ctx, client, namespace, environmentName),
-		Ingresses:     make(map[platform.TenantId]platform.EnvironmentIngress),
+		Ingresses:     make(platform.EnvironmentIngresses),
 	}
 }
 
@@ -169,7 +169,7 @@ func getTenants(ctx context.Context, client *kubernetes.Clientset, namespace, en
 	return tenants
 }
 
-func addIngressesIntoEnvironment(environment *platform.HttpInputEnvironment, ctx context.Context, client *kubernetes.Clientset, namespace string, deployment appsV1.Deployment) map[platform.TenantId]platform.EnvironmentIngress {
+func addIngressesIntoEnvironment(environment *platform.HttpInputEnvironment, ctx context.Context, client *kubernetes.Clientset, namespace string, deployment appsV1.Deployment) platform.EnvironmentIngresses {
 	ingresses := environment.Ingresses
 	for _, ingress := range getIngresses(ctx, client, namespace, deployment) {
 		if len(ingress.Spec.TLS) > 0 {

--- a/pkg/platform/application/service.go
+++ b/pkg/platform/application/service.go
@@ -102,14 +102,28 @@ func (s *service) SaveEnvironment(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *service) validateEnvironmentDoesNotExist(inputEnvironment platform.HttpInputEnvironment, storedEnvironments []platform.HttpInputEnvironment) error {
+	if err := s.validateEnvironmentNameDoesNotExist(inputEnvironment.Name, storedEnvironments); err != nil {
+		return err
+	}
+	if err := s.validateEnvironmentIngressesDoesNotExist(inputEnvironment, storedEnvironments); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) validateEnvironmentNameDoesNotExist(inputEnvironmentName string, storedEnvironments []platform.HttpInputEnvironment) error {
 	environmentNameExists := funk.Contains(storedEnvironments, func(storedEnvironment platform.HttpInputEnvironment) bool {
-		return storedEnvironment.Name == inputEnvironment.Name
+		return storedEnvironment.Name == inputEnvironmentName
 	})
 
 	if environmentNameExists {
-		return errors.New(fmt.Sprintf("Environment %s already exists", inputEnvironment.Name))
+		return errors.New(fmt.Sprintf("Environment %s already exists", inputEnvironmentName))
 	}
+	return nil
+}
 
+func (s *service) validateEnvironmentIngressesDoesNotExist(inputEnvironment platform.HttpInputEnvironment, storedEnvironments []platform.HttpInputEnvironment) error {
 	var usedDomainPrefix string
 	// TODO this is not going to work with custom domains.
 	// Simple logic to make sure the domainPrefix is not used

--- a/pkg/platform/application/service.go
+++ b/pkg/platform/application/service.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -82,22 +83,8 @@ func (s *service) SaveEnvironment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO this is not going to work with custom domains.
-	// Simple logic to make sure the domainPrefix is not used
-	// This is not great and should be linked to actual domains
-	exists := funk.Contains(application.Environments, func(environment platform.HttpInputEnvironment) bool {
-		found := false
-		if environment.Name == input.Name {
-			found = true
-		}
-		if environment.DomainPrefix == input.DomainPrefix {
-			found = true
-		}
-		return found
-	})
-
-	if exists {
-		utils.RespondWithError(w, http.StatusBadRequest, fmt.Sprintf("Environment %s already exists", input.Name))
+	if err := s.validateEnvironmentDoesNotExist(input, application.Environments); err != nil {
+		utils.RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -112,6 +99,37 @@ func (s *service) SaveEnvironment(w http.ResponseWriter, r *http.Request) {
 	// TODO need to create network policy for the environment
 	// https://app.asana.com/0/1200181647276434/1200407495881663/f
 	utils.RespondWithJSON(w, http.StatusOK, input)
+}
+
+func (s *service) validateEnvironmentDoesNotExist(inputEnvironment platform.HttpInputEnvironment, storedEnvironments []platform.HttpInputEnvironment) error {
+	environmentNameExists := funk.Contains(storedEnvironments, func(storedEnvironment platform.HttpInputEnvironment) bool {
+		return storedEnvironment.Name == inputEnvironment.Name
+	})
+
+	if environmentNameExists {
+		return errors.New(fmt.Sprintf("Environment %s already exists", inputEnvironment.Name))
+	}
+
+	var usedDomainPrefix string
+	// TODO this is not going to work with custom domains.
+	// Simple logic to make sure the domainPrefix is not used
+	// This is not great and should be linked to actual domains
+	domainPrefixAlreadyUsed := funk.Contains(storedEnvironments, func(storedEnvironment platform.HttpInputEnvironment) bool {
+		for _, storedIngress := range storedEnvironment.Ingresses {
+			domainPrefixAlreadyUsed := funk.Contains(inputEnvironment.Ingresses, func(_ platform.TenantId, inputIngress platform.EnvironmentIngress) bool {
+				return inputIngress.DomainPrefix == storedIngress.DomainPrefix
+			})
+			if domainPrefixAlreadyUsed {
+				usedDomainPrefix = storedIngress.DomainPrefix
+				return true
+			}
+		}
+		return false
+	})
+	if domainPrefixAlreadyUsed {
+		return errors.New(fmt.Sprintf("Cannot save environment %s because an ingress with domain prefix %s already exists", inputEnvironment.Name, usedDomainPrefix))
+	}
+	return nil
 }
 
 func (s *service) Create(w http.ResponseWriter, r *http.Request) {

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -28,13 +28,14 @@ type EnvironmentIngress struct {
 	Host         string `json:"host"`
 	DomainPrefix string `json:"domainPrefix"`
 }
+type EnvironmentIngresses map[TenantId]EnvironmentIngress
 type HttpInputEnvironment struct {
-	AutomationEnabled bool                            `json:"automationEnabled"`
-	Name              string                          `json:"name"`
-	TenantID          string                          `json:"tenantId"`
-	ApplicationID     string                          `json:"applicationId"`
-	Tenants           []TenantId                      `json:"tenants"`
-	Ingresses         map[TenantId]EnvironmentIngress `json:"ingresses"`
+	AutomationEnabled bool                 `json:"automationEnabled"`
+	Name              string               `json:"name"`
+	TenantID          string               `json:"tenantId"`
+	ApplicationID     string               `json:"applicationId"`
+	Tenants           []TenantId           `json:"tenants"`
+	Ingresses         EnvironmentIngresses `json:"ingresses"`
 }
 
 type HttpResponseApplication2 struct {

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -22,13 +22,19 @@ type HttpInputApplication struct {
 	TenantID string `json:"tenantId"`
 }
 
+type TenantId string
+
+type EnvironmentIngress struct {
+	Host         string `json:"host"`
+	DomainPrefix string `json:"domainPrefix"`
+}
 type HttpInputEnvironment struct {
-	Name              string `json:"name"`
-	DomainPrefix      string `json:"domainPrefix"`
-	Host              string `json:"host"`
-	TenantID          string `json:"tenantId"`
-	ApplicationID     string `json:"applicationId"`
-	AutomationEnabled bool   `json:"automationEnabled"`
+	AutomationEnabled bool                            `json:"automationEnabled"`
+	Name              string                          `json:"name"`
+	TenantID          string                          `json:"tenantId"`
+	ApplicationID     string                          `json:"applicationId"`
+	Tenants           []TenantId                      `json:"tenants"`
+	Ingresses         map[TenantId]EnvironmentIngress `json:"ingresses"`
 }
 
 type HttpResponseApplication2 struct {

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -27,8 +27,11 @@ type TenantId string
 type EnvironmentIngress struct {
 	Host         string `json:"host"`
 	DomainPrefix string `json:"domainPrefix"`
+	SecretName   string `json:"secretName"`
 }
+
 type EnvironmentIngresses map[TenantId]EnvironmentIngress
+
 type HttpInputEnvironment struct {
 	AutomationEnabled bool                 `json:"automationEnabled"`
 	Name              string               `json:"name"`
@@ -50,6 +53,7 @@ type HttpResponseApplication struct {
 	ID           string                 `json:"id"`
 	Name         string                 `json:"name"`
 	TenantID     string                 `json:"tenantId"`
+	TenantName   string                 `json:"tenantName"`
 	Environments []HttpInputEnvironment `json:"environments"`
 }
 


### PR DESCRIPTION
## Summary

Changes the structure of the HttpInputEnvironment struct so that it knows about the tenants and has a mapping between tenant Id and ingress.

There are some assumptions in play around the ingresses that are added to the map. First it assumes that the ingresses that needs to be configured has one or more spec.TLS items. Secondly it will override the ingress config for a tenant. It also maybe clunkily extracts the tenant id from the ingress from the nginx.ingress.kubernetes.io/configuration-snippet annotation. 

### Changed

- Changed structure of HttpInputEnvironment to include a list of tenants and a mapping between tenant id and ingress host and domain prefix
- build-applications command to store applications with this new structure

# Reference
- https://app.asana.com/0/1200879032451150/1200931738686043/f