### PR TITLE
Use configured tenant when creating POAPI and RawDataLogIngestor

### DIFF
--- a/pkg/platform/application.go
+++ b/pkg/platform/application.go
@@ -1,0 +1,65 @@
+package platform
+
+import (
+	"fmt"
+
+	"github.com/thoas/go-funk"
+)
+
+// NoConfiguredEnvironmentsError is the error that occurs when getting the tenant for an environment of a stored application
+// that does not have any environments configured
+type NoConfiguredEnvironmentsError struct {
+	application HttpResponseApplication
+}
+
+func (e *NoConfiguredEnvironmentsError) Error() string {
+	return fmt.Sprintf("There are no environments configured for application %s under customer %s", e.application.ID, e.application.TenantID)
+}
+
+// EnvironmentNotFoundError is the error that occurs when getting the tenant for an environment of a stored application
+// that does not have the specific environment configured
+type EnvironmentNotFoundError struct {
+	application HttpResponseApplication
+	environment string
+}
+
+func (e *EnvironmentNotFoundError) Error() string {
+	return fmt.Sprintf("Environment %s is not configured for application %s under customer %s", e.environment, e.application.ID, e.application.TenantID)
+}
+
+// NoConfiguredTenantsError is the error that occurs when getting the tenant for an environment of a stored application
+// that does not have any tenants configured
+type NoConfiguredTenantsError struct {
+	application HttpResponseApplication
+	environment string
+}
+
+func (e *NoConfiguredTenantsError) Error() string {
+	return fmt.Sprintf("Environment %s under application %s under customer %s does not have any configured tenants", e.environment, e.application.ID, e.application.TenantID)
+}
+
+// GetTenantForEnvironment gets the topmost tenant in the configured list of tenants for the application configuration
+func (a HttpResponseApplication) GetTenantForEnvironment(environment string) (TenantId, error) {
+	tenants, err := a.getTenantsInEnvironment(environment)
+	if err != nil {
+		return "", err
+	}
+	if len(tenants) == 0 {
+		return "", &NoConfiguredTenantsError{a, environment}
+	}
+	return tenants[0], nil
+}
+
+func (a HttpResponseApplication) getTenantsInEnvironment(desiredEnvironmentName string) ([]TenantId, error) {
+	environments := a.Environments
+	if len(environments) == 0 {
+		return make([]TenantId, 0), &NoConfiguredEnvironmentsError{a}
+	}
+	index := funk.IndexOf(environments, func(e HttpInputEnvironment) bool {
+		return e.Name == desiredEnvironmentName
+	})
+	if index == -1 {
+		return make([]TenantId, 0), &EnvironmentNotFoundError{a, desiredEnvironmentName}
+	}
+	return environments[index].Tenants, nil
+}

--- a/pkg/platform/application_test.go
+++ b/pkg/platform/application_test.go
@@ -1,0 +1,105 @@
+package platform_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/dolittle-entropy/platform-api/pkg/platform"
+)
+
+var _ = Describe("Application", func() {
+	var (
+		application platform.HttpResponseApplication
+	)
+	BeforeEach(func() {
+		application = platform.HttpResponseApplication{
+			ID:           "9b5c27c5-3e7c-4d3b-9e5f-df3401b6d61d",
+			Name:         "Some application",
+			TenantID:     "16a57ea2-0142-45f1-9c5b-e92705b9cbfb",
+			TenantName:   "Some tenant",
+			Environments: make([]platform.HttpInputEnvironment, 0),
+		}
+	})
+	Describe("for GetTenantForEnvironment", func() {
+		var (
+			resultTenant platform.TenantId
+			resultErr    error
+		)
+		Describe("and there are no environments", func() {
+			BeforeEach(func() {
+				_, resultErr = application.GetTenantForEnvironment("Prod")
+			})
+			It("should fail because there are no configured environments", func() {
+				var expectedErr *platform.NoConfiguredEnvironmentsError
+				Expect(errors.As(resultErr, &expectedErr)).To(BeTrue())
+			})
+		})
+		Describe("and environment is not found", func() {
+			BeforeEach(func() {
+				application.Environments = append(application.Environments, platform.HttpInputEnvironment{
+					Name: "Dev",
+				})
+				_, resultErr = application.GetTenantForEnvironment("Prod")
+			})
+			It("should fail because environment was not found", func() {
+				var expectedErr *platform.EnvironmentNotFoundError
+				Expect(errors.As(resultErr, &expectedErr)).To(BeTrue())
+			})
+		})
+		Describe("and there are no configured tenants for environment", func() {
+			BeforeEach(func() {
+				application.Environments = append(application.Environments, platform.HttpInputEnvironment{
+					Name:    "Prod",
+					Tenants: make([]platform.TenantId, 0),
+				})
+				_, resultErr = application.GetTenantForEnvironment("Prod")
+			})
+			It("should fail because environment was not found", func() {
+				var expectedErr *platform.NoConfiguredTenantsError
+				Expect(errors.As(resultErr, &expectedErr)).To(BeTrue())
+			})
+		})
+		Describe("and there is one configured tenant for environment", func() {
+			var configuredTenant platform.TenantId
+			BeforeEach(func() {
+				configuredTenant = "8e63a95c-e24b-44d2-a19b-0bebdc8a0832"
+				application.Environments = append(application.Environments, platform.HttpInputEnvironment{
+					Name:    "Prod",
+					Tenants: append(make([]platform.TenantId, 0), configuredTenant),
+				})
+				resultTenant, resultErr = application.GetTenantForEnvironment("Prod")
+			})
+			It("should not fail", func() {
+				Expect(resultErr).To(BeNil())
+			})
+			It("should get the configured tenant", func() {
+				Expect(resultTenant).To(Equal(configuredTenant))
+			})
+		})
+		Describe("and there are multiple configured tenants for environment", func() {
+			var (
+				firstConfiguredTenant  platform.TenantId
+				secondConfiguredTenant platform.TenantId
+				thirdConfiguredTenant  platform.TenantId
+			)
+			BeforeEach(func() {
+				firstConfiguredTenant = "8e63a95c-e24b-44d2-a19b-0bebdc8a0832"
+				secondConfiguredTenant = "a7c5eb38-741b-4d90-b33a-5cad0ee9d52c"
+				thirdConfiguredTenant = "ff2d4862-5405-476d-91f5-331c83872687"
+				application.Environments = append(application.Environments, platform.HttpInputEnvironment{
+					Name:    "Prod",
+					Tenants: append(make([]platform.TenantId, 0), firstConfiguredTenant, secondConfiguredTenant, thirdConfiguredTenant),
+				})
+				resultTenant, resultErr = application.GetTenantForEnvironment("Prod")
+			})
+			It("should not fail", func() {
+				Expect(resultErr).To(BeNil())
+			})
+			It("should get the first configured tenant", func() {
+				Expect(resultTenant).To(Equal(firstConfiguredTenant))
+			})
+		})
+	})
+})

--- a/pkg/platform/microservice/purchaseorderapi/doc.go
+++ b/pkg/platform/microservice/purchaseorderapi/doc.go
@@ -11,17 +11,17 @@ import (
 
 type Repo interface {
 	// Create creates the microservice by committing it to a persistent storage and applying its kubernetes resources
-	Create(namespace string, tenant k8s.Tenant, application k8s.Application, input platform.HttpInputPurchaseOrderInfo) error
+	Create(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) error
 	// Delete deletes the microservice by deleting its kubernetes resources
 	Delete(namespace, microserviceID string) error
 }
 
 type K8sResource interface {
-	Create(namspace, headImage, runtimeImage string, k8sMicroservice k8s.Microservice, extra platform.HttpInputPurchaseOrderExtra, ctx context.Context) error
+	Create(namspace, headImage, runtimeImage string, k8sMicroservice k8s.Microservice, tenant platform.TenantId, extra platform.HttpInputPurchaseOrderExtra, ctx context.Context) error
 	Delete(namespace, microserviceID string, ctx context.Context) error
 }
 type K8sResourceSpecFactory interface {
-	CreateAll(headImage, runtimeImage string, k8sMicroservice k8s.Microservice, extra platform.HttpInputPurchaseOrderExtra) K8sResources
+	CreateAll(headImage, runtimeImage string, k8sMicroservice k8s.Microservice, tenant platform.TenantId, extra platform.HttpInputPurchaseOrderExtra) K8sResources
 }
 type K8sResources struct {
 	MicroserviceConfigMap *corev1.ConfigMap

--- a/pkg/platform/microservice/purchaseorderapi/handler.go
+++ b/pkg/platform/microservice/purchaseorderapi/handler.go
@@ -30,7 +30,17 @@ func (s *RequestHandler) Create(responseWriter http.ResponseWriter, r *http.Requ
 		return parserError
 	}
 
-	err := s.repo.Create(msK8sInfo.Namespace, msK8sInfo.Tenant, msK8sInfo.Application, ms)
+	application, err := s.gitRepo.GetApplication(applicationInfo.Tenant.ID, applicationInfo.ID)
+	if err != nil {
+		utils.RespondWithError(responseWriter, http.StatusInternalServerError, err.Error())
+		return err
+	}
+	tenant, err := application.GetTenantForEnvironment(ms.Environment)
+	if err != nil {
+		utils.RespondWithError(responseWriter, http.StatusInternalServerError, err.Error())
+		return err
+	}
+	err = s.repo.Create(msK8sInfo.Namespace, msK8sInfo.Tenant, msK8sInfo.Application, tenant, ms)
 	if err != nil {
 		utils.RespondWithError(responseWriter, http.StatusInternalServerError, err.Error())
 		return nil

--- a/pkg/platform/microservice/purchaseorderapi/k8sResource.go
+++ b/pkg/platform/microservice/purchaseorderapi/k8sResource.go
@@ -26,10 +26,10 @@ func NewK8sResource(k8sClient *kubernetes.Clientset, specFactory K8sResourceSpec
 }
 
 // Create creates a new PurchaseOrderAPI microservice, and a RawDataLog and WebhookListener if they don't exist.
-func (r *k8sResource) Create(namespace, headImage, runtimeImage string, k8sMicroservice k8s.Microservice, extra platform.HttpInputPurchaseOrderExtra, ctx context.Context) error {
+func (r *k8sResource) Create(namespace, headImage, runtimeImage string, k8sMicroservice k8s.Microservice, tenant platform.TenantId, extra platform.HttpInputPurchaseOrderExtra, ctx context.Context) error {
 	opts := metaV1.CreateOptions{}
 
-	resources := r.specFactory.CreateAll(headImage, runtimeImage, k8sMicroservice, extra)
+	resources := r.specFactory.CreateAll(headImage, runtimeImage, k8sMicroservice, tenant, extra)
 
 	// ConfigMaps
 	_, err := r.k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, resources.MicroserviceConfigMap, opts)

--- a/pkg/platform/microservice/purchaseorderapi/k8sResourceSpecFactory_test.go
+++ b/pkg/platform/microservice/purchaseorderapi/k8sResourceSpecFactory_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/dolittle-entropy/platform-api/pkg/platform"
-	microserviceK8s "github.com/dolittle-entropy/platform-api/pkg/platform/microservice/k8s"
 	. "github.com/dolittle-entropy/platform-api/pkg/platform/microservice/purchaseorderapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,6 +29,7 @@ var _ = Describe("For k8sResourceSpecFactory", func() {
 			k8sMicroservice k8s.Microservice
 			result          K8sResources
 			rawDataLogName  string
+			tenant          platform.TenantId
 		)
 
 		BeforeEach(func() {
@@ -43,8 +43,9 @@ var _ = Describe("For k8sResourceSpecFactory", func() {
 					ID:   "12345-789",
 				},
 			}
+			tenant = "fd93dfc9-8c44-4db7-844f-c0fde955792a"
 			rawDataLogName = "raw-data-log-123"
-			result = factory.CreateAll(headImage, runtimeImage, k8sMicroservice, platform.HttpInputPurchaseOrderExtra{
+			result = factory.CreateAll(headImage, runtimeImage, k8sMicroservice, tenant, platform.HttpInputPurchaseOrderExtra{
 				RawDataLogName: rawDataLogName,
 			})
 		})
@@ -67,7 +68,7 @@ var _ = Describe("For k8sResourceSpecFactory", func() {
 			Expect(result.ConfigEnvVariables.Data["NODE_ENV"]).To(Equal("production"))
 		})
 		It("should set TENANT to the todo-customer-tenant-id", func() {
-			Expect(result.ConfigEnvVariables.Data["TENANT"]).To(Equal(microserviceK8s.TodoCustomersTenantID))
+			Expect(result.ConfigEnvVariables.Data["TENANT"]).To(BeEquivalentTo(tenant))
 		})
 		It("should set SERVER_PORT to '8080'", func() {
 			Expect(result.ConfigEnvVariables.Data["SERVER_PORT"]).To(Equal("8080"))

--- a/pkg/platform/microservice/purchaseorderapi/repo.go
+++ b/pkg/platform/microservice/purchaseorderapi/repo.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/dolittle-entropy/platform-api/pkg/dolittle/k8s"
 	"github.com/dolittle-entropy/platform-api/pkg/platform"
-	microserviceK8s "github.com/dolittle-entropy/platform-api/pkg/platform/microservice/k8s"
 	"github.com/dolittle-entropy/platform-api/pkg/platform/microservice/rawdatalog"
 )
 
@@ -23,7 +22,7 @@ func NewRepo(k8sResource K8sResource, rawDataLogIngestorRepo rawdatalog.RawDataL
 }
 
 // Create creates a new PurchaseOrderAPI microservice, and a RawDataLog and WebhookListener if they don't exist.
-func (r *repo) Create(namespace string, tenant k8s.Tenant, application k8s.Application, input platform.HttpInputPurchaseOrderInfo) error {
+func (r *repo) Create(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) error {
 	// TODO not sure where this comes from really, assume dynamic
 
 	environment := input.Environment
@@ -35,10 +34,10 @@ func (r *repo) Create(namespace string, tenant k8s.Tenant, application k8s.Appli
 	microservice := k8s.Microservice{
 		ID:          microserviceID,
 		Name:        microserviceName,
-		Tenant:      tenant,
+		Tenant:      customer,
 		Application: application,
 		Environment: environment,
-		ResourceID:  microserviceK8s.TodoCustomersTenantID,
+		ResourceID:  string(tenant),
 		Kind:        platform.MicroserviceKindPurchaseOrderAPI,
 	}
 
@@ -48,7 +47,7 @@ func (r *repo) Create(namespace string, tenant k8s.Tenant, application k8s.Appli
 	// 	return err
 	// }
 
-	if err := r.k8sResource.Create(namespace, headImage, runtimeImage, microservice, input.Extra, ctx); err != nil {
+	if err := r.k8sResource.Create(namespace, headImage, runtimeImage, microservice, tenant, input.Extra, ctx); err != nil {
 		return err
 	}
 

--- a/pkg/platform/microservice/rawdatalog/repo.go
+++ b/pkg/platform/microservice/rawdatalog/repo.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dolittle-entropy/platform-api/pkg/dolittle/k8s"
 	"github.com/dolittle-entropy/platform-api/pkg/platform"
+	"github.com/dolittle-entropy/platform-api/pkg/platform/storage"
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -44,12 +45,14 @@ var decUnstructured = yaml.NewDecodingSerializer(unstructured.UnstructuredJSONSc
 type RawDataLogIngestorRepo struct {
 	k8sClient       *kubernetes.Clientset
 	k8sDolittleRepo platform.K8sRepo
+	gitRepo         storage.Repo
 }
 
-func NewRawDataLogIngestorRepo(k8sDolittleRepo platform.K8sRepo, k8sClient *kubernetes.Clientset) RawDataLogIngestorRepo {
+func NewRawDataLogIngestorRepo(k8sDolittleRepo platform.K8sRepo, k8sClient *kubernetes.Clientset, gitRepo storage.Repo) RawDataLogIngestorRepo {
 	return RawDataLogIngestorRepo{
 		k8sClient:       k8sClient,
 		k8sDolittleRepo: k8sDolittleRepo,
+		gitRepo:         gitRepo,
 	}
 }
 
@@ -61,7 +64,7 @@ func (r RawDataLogIngestorRepo) Update(namespace string, tenant k8s.Tenant, appl
 	return errors.New("TODO")
 }
 
-func (r RawDataLogIngestorRepo) Create(namespace string, tenant k8s.Tenant, application k8s.Application, applicationIngress k8s.Ingress, input platform.HttpInputRawDataLogIngestorInfo) error {
+func (r RawDataLogIngestorRepo) Create(namespace string, customer k8s.Tenant, application k8s.Application, applicationIngress k8s.Ingress, input platform.HttpInputRawDataLogIngestorInfo) error {
 	config := r.k8sDolittleRepo.GetRestConfig()
 	ctx := context.TODO()
 
@@ -71,14 +74,14 @@ func (r RawDataLogIngestorRepo) Create(namespace string, tenant k8s.Tenant, appl
 	}
 
 	labels := map[string]string{
-		"tenant":       tenant.Name,
+		"tenant":       customer.Name,
 		"application":  application.Name,
 		"environment":  input.Environment,
 		"microservice": input.Name,
 	}
 
 	annotations := map[string]string{
-		"dolittle.io/tenant-id":       tenant.ID,
+		"dolittle.io/tenant-id":       customer.ID,
 		"dolittle.io/application-id":  application.ID,
 		"dolittle.io/microservice-id": input.Dolittle.MicroserviceID,
 	}
@@ -105,7 +108,7 @@ func (r RawDataLogIngestorRepo) Create(namespace string, tenant k8s.Tenant, appl
 	}
 
 	// TODO add microservice
-	err := r.doDolittle(namespace, tenant, application, applicationIngress, input)
+	err := r.doDolittle(namespace, customer, application, applicationIngress, input)
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -341,10 +344,10 @@ func doNats(
 	return doDo(obj, dr, action, ctx)
 }
 
-func (r RawDataLogIngestorRepo) doDolittle(namespace string, tenant k8s.Tenant, application k8s.Application, applicationIngress k8s.Ingress, input platform.HttpInputRawDataLogIngestorInfo) error {
+func (r RawDataLogIngestorRepo) doDolittle(namespace string, customer k8s.Tenant, application k8s.Application, applicationIngress k8s.Ingress, input platform.HttpInputRawDataLogIngestorInfo) error {
 
 	// TODO not sure where this comes from really, assume dynamic
-	customersTenantID := "17426336-fb8e-4425-8ab7-07d488367be9"
+	// tenantID := "17426336-fb8e-4425-8ab7-07d488367be9"
 
 	environment := input.Environment
 	host := applicationIngress.Host
@@ -358,10 +361,10 @@ func (r RawDataLogIngestorRepo) doDolittle(namespace string, tenant k8s.Tenant, 
 	microservice := k8s.Microservice{
 		ID:          microserviceID,
 		Name:        microserviceName,
-		Tenant:      tenant,
+		Tenant:      customer,
 		Application: application,
 		Environment: environment,
-		ResourceID:  customersTenantID,
+		ResourceID:  tenantID,
 	}
 
 	ingressServiceName := strings.ToLower(fmt.Sprintf("%s-%s", microservice.Environment, microservice.Name))
@@ -380,7 +383,7 @@ func (r RawDataLogIngestorRepo) doDolittle(namespace string, tenant k8s.Tenant, 
 
 	// TODO do I need this?
 	// TODO if I remove it, do I remove the config mapping?
-	microserviceConfigmap := k8s.NewMicroserviceConfigmap(microservice, customersTenantID)
+	microserviceConfigmap := k8s.NewMicroserviceConfigmap(microservice, tenantID)
 	deployment := k8s.NewDeployment(microservice, headImage, runtimeImage)
 	service := k8s.NewService(microservice)
 	ingress := k8s.NewIngress(microservice)
@@ -411,7 +414,7 @@ func (r RawDataLogIngestorRepo) doDolittle(namespace string, tenant k8s.Tenant, 
 		"WEBHOOK_REPO":            input.Extra.WriteTo,
 		"LISTEN_ON":               "0.0.0.0:8080",
 		"WEBHOOK_PREFIX":          webhookPrefix,
-		"DOLITTLE_TENANT_ID":      tenant.ID,
+		"DOLITTLE_TENANT_ID":      customer.ID,
 		"DOLITTLE_APPLICATION_ID": application.ID,
 		"DOLITTLE_ENVIRONMENT":    environment,
 		"MICROSERVICE_CONFIG":     "/app/data/microservice_data_from_studio.json",

--- a/pkg/platform/microservice/service.go
+++ b/pkg/platform/microservice/service.go
@@ -24,7 +24,7 @@ import (
 
 func NewService(gitRepo storage.Repo, k8sDolittleRepo platform.K8sRepo, k8sClient *kubernetes.Clientset) service {
 	parser := parser.NewJsonParser()
-	rawDataLogRepo := rawdatalog.NewRawDataLogIngestorRepo(k8sDolittleRepo, k8sClient)
+	rawDataLogRepo := rawdatalog.NewRawDataLogIngestorRepo(k8sDolittleRepo, k8sClient, gitRepo)
 	specFactory := purchaseorderapi.NewK8sResourceSpecFactory()
 	k8sResources := purchaseorderapi.NewK8sResource(k8sClient, specFactory)
 

--- a/pkg/platform/microservice/service.go
+++ b/pkg/platform/microservice/service.go
@@ -93,7 +93,7 @@ func (s *service) Create(responseWriter http.ResponseWriter, request *http.Reque
 			responseWriter,
 			http.StatusBadRequest,
 			fmt.Sprintf(
-				"Tenant %s with application %s in environment %s does not allow changes via Studio",
+				"Customer %s with application %s in environment %s does not allow changes via Studio",
 				customer.ID,
 				applicationID,
 				environment,

--- a/pkg/platform/microservice/service.go
+++ b/pkg/platform/microservice/service.go
@@ -78,23 +78,23 @@ func (s *service) Create(responseWriter http.ResponseWriter, request *http.Reque
 		return
 	}
 
-	tenant := k8s.Tenant{
+	customer := k8s.Tenant{
 		ID:   applicationInfo.Tenant.ID,
 		Name: applicationInfo.Tenant.Name,
 	}
 
-	allowed := s.k8sDolittleRepo.CanModifyApplicationWithResponse(responseWriter, tenant.ID, applicationID, userID)
+	allowed := s.k8sDolittleRepo.CanModifyApplicationWithResponse(responseWriter, customer.ID, applicationID, userID)
 	if !allowed {
 		return
 	}
 
-	if !s.gitRepo.IsAutomationEnabled(tenant.ID, applicationID, environment) {
+	if !s.gitRepo.IsAutomationEnabled(customer.ID, applicationID, environment) {
 		utils.RespondWithError(
 			responseWriter,
 			http.StatusBadRequest,
 			fmt.Sprintf(
 				"Tenant %s with application %s in environment %s does not allow changes via Studio",
-				tenant.ID,
+				customer.ID,
 				applicationID,
 				environment,
 			),

--- a/pkg/platform/platform_suite_test.go
+++ b/pkg/platform/platform_suite_test.go
@@ -1,0 +1,13 @@
+package platform_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPlatform(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Platform Suite")
+}


### PR DESCRIPTION
## Summary

When creating Purchase Order API microservice or RawDataLogIngestor microservice it is important to configure it to the correct tenant. The tenant being used before was just a static tenant, it needs to not be static in order for it to work with actual customers.

There are a few caveats at the moment:
- It will only use one tenant. For instance if we needed a Purchase Order API to commit events to multiple tenants that wouldn't work with the current solution
- The added configured tenant is not used for the other microservices yet. Only used for Purchase Order API and RawDataLogIngestor
- When we want to do this for normal microservices we need to change this to configure for all tenants, not just the first one 

### Added

- A method for getting tenant for environment on the application metadata stored in git
- Specs for method for getting tenant for environment on the application metadata stored in git 

### Changed

- The tenant used when creating Purchase Order API and RawDataLogIngestor
- A couple of places in the code 'tenant' parameter was renamed to 'customer' to make it more explicit that the tenant actually represents a Dolittle customer
