### PR TITLE
Change the configured http port for POapi

### DIFF
--- a/pkg/platform/microservice/purchaseorderapi/k8sResourceSpecFactory.go
+++ b/pkg/platform/microservice/purchaseorderapi/k8sResourceSpecFactory.go
@@ -42,7 +42,7 @@ func (r *k8sResourceSpecFactory) modifyEnvironmentVariablesConfigMap(environment
 		"DATABASE_READMODELS_NAME":  readmodelDBName,
 		"NODE_ENV":                  "production",
 		"TENANT":                    tenantID,
-		"SERVER_PORT":               "8080",
+		"SERVER_PORT":               "80",
 		"NATS_CLUSTER_URL":          natsClusterURL,
 		"NATS_START_FROM_BEGINNING": "false",
 		"LOG_OUTPUT_FORMAT":         "json",

--- a/pkg/platform/microservice/purchaseorderapi/k8sResourceSpecFactory_test.go
+++ b/pkg/platform/microservice/purchaseorderapi/k8sResourceSpecFactory_test.go
@@ -69,7 +69,7 @@ var _ = Describe("For k8sResourceSpecFactory", func() {
 			Expect(result.ConfigEnvVariables.Data["TENANT"]).To(BeEquivalentTo(tenant))
 		})
 		It("should set SERVER_PORT to '8080'", func() {
-			Expect(result.ConfigEnvVariables.Data["SERVER_PORT"]).To(Equal("8080"))
+			Expect(result.ConfigEnvVariables.Data["SERVER_PORT"]).To(Equal("80"))
 		})
 		It("should set the correct NATS_CLUSTER_URL", func() {
 			Expect(result.ConfigEnvVariables.Data["NATS_CLUSTER_URL"]).To(Equal("prod-nats.application-12345-789.svc.cluster.local:4222"))


### PR DESCRIPTION
## Summary

Fixes the configured HTTP listen on port when deploying a PurchaseOrderAPI microservice, so that it conforms to the convention in the platform (to listen on port 80 for the ingress). Even though we don't have an ingress automatically set up for it now, this makes the pod listen on the port that the service expects it to. So that when we do want to create an ingress (to port 'http') this will work.

I have tested this locally with k3d, and it works.

### Fixed

- Change the created environmental variables for the PurchaseOrderAPI deployment so that it listens on port 80 instead of 8080
