### PR TITLE
Only allow single PurchaseOrderAPI per environment

### DIFF
--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -16,5 +16,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: major,minor,patch
+          one_of: major,minor,patch,no-release
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -1,0 +1,20 @@
+name: Verify release labels
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  check_labels:
+    name: Check labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: major,minor,patch
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/pkg/platform/microservice/purchaseorderapi/doc.go
+++ b/pkg/platform/microservice/purchaseorderapi/doc.go
@@ -14,8 +14,10 @@ type Repo interface {
 	Create(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) error
 	// Delete deletes the microservice by deleting its kubernetes resources
 	Delete(namespace, microserviceID string) error
-	// Exists checks whether the purchase order api has already been created
+	// Exists checks whether a purchase order api with the same name has already been created
 	Exists(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) (bool, error)
+	// EnvironmentHasPurchaseOrderAPI checks whether the given environment has a purchase order api deployed
+	EnvironmentHasPurchaseOrderAPI(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) (bool, error)
 }
 
 type K8sResource interface {

--- a/pkg/platform/microservice/purchaseorderapi/doc.go
+++ b/pkg/platform/microservice/purchaseorderapi/doc.go
@@ -17,7 +17,7 @@ type Repo interface {
 	// Exists checks whether a purchase order api with the same name has already been created
 	Exists(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) (bool, error)
 	// EnvironmentHasPurchaseOrderAPI checks whether the given environment has a purchase order api deployed
-	EnvironmentHasPurchaseOrderAPI(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) (bool, error)
+	EnvironmentHasPurchaseOrderAPI(namespace string, input platform.HttpInputPurchaseOrderInfo) (bool, error)
 }
 
 type K8sResource interface {

--- a/pkg/platform/microservice/purchaseorderapi/handler.go
+++ b/pkg/platform/microservice/purchaseorderapi/handler.go
@@ -54,7 +54,17 @@ func (s *RequestHandler) Create(responseWriter http.ResponseWriter, r *http.Requ
 		return err
 	}
 
-	exists, err := s.repo.Exists(msK8sInfo.Namespace, msK8sInfo.Tenant, msK8sInfo.Application, tenant, ms)
+	exists, err := s.repo.EnvironmentHasPurchaseOrderAPI(msK8sInfo.Namespace, msK8sInfo.Tenant, msK8sInfo.Application, tenant, ms)
+	if err != nil {
+		utils.RespondWithError(responseWriter, http.StatusInternalServerError, err.Error())
+		return err
+	}
+	if exists {
+		utils.RespondWithError(responseWriter, http.StatusConflict, fmt.Sprintf("A Purchase Order API Microservice already exists in %s enironment in application %s under customer %s", ms.Environment, ms.Dolittle.ApplicationID, ms.Dolittle.TenantID))
+		return nil
+	}
+
+	exists, err = s.repo.Exists(msK8sInfo.Namespace, msK8sInfo.Tenant, msK8sInfo.Application, tenant, ms)
 	if err != nil {
 		utils.RespondWithError(responseWriter, http.StatusInternalServerError, err.Error())
 		return err

--- a/pkg/platform/microservice/purchaseorderapi/handler.go
+++ b/pkg/platform/microservice/purchaseorderapi/handler.go
@@ -54,7 +54,7 @@ func (s *RequestHandler) Create(responseWriter http.ResponseWriter, r *http.Requ
 		return err
 	}
 
-	exists, err := s.repo.EnvironmentHasPurchaseOrderAPI(msK8sInfo.Namespace, msK8sInfo.Tenant, msK8sInfo.Application, tenant, ms)
+	exists, err := s.repo.EnvironmentHasPurchaseOrderAPI(msK8sInfo.Namespace, ms)
 	if err != nil {
 		utils.RespondWithError(responseWriter, http.StatusInternalServerError, err.Error())
 		return err

--- a/pkg/platform/microservice/purchaseorderapi/repo.go
+++ b/pkg/platform/microservice/purchaseorderapi/repo.go
@@ -82,7 +82,7 @@ func (r *repo) Exists(namespace string, customer k8s.Tenant, application k8s.App
 	return exists, nil
 }
 
-func (r *repo) EnvironmentHasPurchaseOrderAPI(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) (bool, error) {
+func (r *repo) EnvironmentHasPurchaseOrderAPI(namespace string, input platform.HttpInputPurchaseOrderInfo) (bool, error) {
 	environmentName := strings.ToLower(input.Environment)
 
 	ctx := context.TODO()

--- a/pkg/platform/microservice/purchaseorderapi/repo.go
+++ b/pkg/platform/microservice/purchaseorderapi/repo.go
@@ -3,6 +3,7 @@ package purchaseorderapi
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/dolittle-entropy/platform-api/pkg/dolittle/k8s"
 	"github.com/dolittle-entropy/platform-api/pkg/platform"
@@ -53,6 +54,7 @@ func (r *repo) Create(namespace string, customer k8s.Tenant, application k8s.App
 
 	return nil
 }
+
 func (r *repo) Exists(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) (bool, error) {
 	environment := input.Environment
 	microserviceID := input.Dolittle.MicroserviceID
@@ -78,6 +80,28 @@ func (r *repo) Exists(namespace string, customer k8s.Tenant, application k8s.App
 		return false, fmt.Errorf("Failed to get purchase order api deployment: %v", err)
 	}
 	return exists, nil
+}
+
+func (r *repo) EnvironmentHasPurchaseOrderAPI(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) (bool, error) {
+	environmentName := strings.ToLower(input.Environment)
+
+	ctx := context.TODO()
+	deployments, err := microserviceK8s.K8sGetDeployments(r.k8sClient, ctx, namespace)
+	if err != nil {
+		return false, err
+	}
+
+	for _, deployment := range deployments {
+		if deployment.Annotations["dolittle.io/microservice-kind"] != string(platform.MicroserviceKindPurchaseOrderAPI) {
+			continue
+		}
+		if environmentName != strings.ToLower(deployment.Labels["environment"]) {
+			continue
+		}
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // Delete stops the running purchase order api and deletes the kubernetes resources.


### PR DESCRIPTION
## Summary

Adds checks to ensure that there doesn't already exist a PurchaseOrderAPI in an environment when creating. The previous logic checked for one with the same name and id, the added code checks for any name and id.

The code might be a bit excessive, as it now first checks the Git storage, and then K8s afterwards. We could get away with one of them, but I'm not sure which one to truly consider the source of truth until we have everything covered by automation. Also might not be clear, but the old check is still useful because it checks for any microservice with the same name (which would cause problems) - even though the naming of the function kind of indicates that it looks for a PurchaseOrderAPI microservice.

I've tested it locally, and also added more specs for the `Exists` method and the new `EnvironmentHasPurchaseOrderAPI` method.

### Added

- Disallow the creation of multiple PurchaseOrderAPIs in the backend.

### Changed

- The structure of the specs for the purchase order api repo
