### PR TITLE
Return "N/A" for start-time when pod is starting up

### DIFF
--- a/pkg/platform/k8s_repo.go
+++ b/pkg/platform/k8s_repo.go
@@ -270,7 +270,10 @@ func (r *K8sRepo) GetPodStatus(applicationID string, microserviceID string, envi
 		response.Microservice.Name = labelMap["microservice"]
 		// Interesting pod.Status.StartTime.String() might not be the same as pod.CreationTimestamp.Time
 		age := time.Since(pod.CreationTimestamp.Time)
-		started := pod.Status.StartTime.String() // Might need to change
+		started := "N/A"
+		if pod.Status.StartTime != nil {
+			started = pod.Status.StartTime.String()
+		}
 
 		containers := funk.Map(pod.Status.ContainerStatuses, func(container coreV1.ContainerStatus) ContainerStatusInfo {
 			// Not sure about this logic, I almost want to drop to the cli :P


### PR DESCRIPTION
## Summary

While a pod I starting up, the StartTime is not set (nil in Go) which caused the "View" screen just after creating e.g. a POapi to fail. This fix just returns "N/A" instead of an actual date when StartTime is nil. The contract was just a plain string anyways, so Studio will accept it.

#### How to test
- Start with a clean cluster (or without raw-data-log and purchase-order)
- Click Microservices
- Click Create new microservice
- Click Create within the Purchase order api card
- Select Infor graphic
- Enter name
- Click next
- Enter username
- Enter password
- Click Next
- At this point, we send the request to the backend and redirect the frontend.
- Observe platform-api __does not__ crash

### Fixed

- Handling of Pod.StartTime nil-values while the pod is still starting up.