### PR TITLE
Raw data log microservice bug

### DIFF
--- a/pkg/platform/microservice/rawdatalog/repo.go
+++ b/pkg/platform/microservice/rawdatalog/repo.go
@@ -372,7 +372,7 @@ func (r RawDataLogIngestorRepo) doDolittle(namespace string, customer k8s.Tenant
 		"method":    "RawDataLogIngestorRepo.doDolittle",
 	}).Debug("Starting to create RawDataLog microservice")
 
-	environment := strings.ToLower(input.Environment)
+	environment := input.Environment
 	host := environmentIngress.Host
 	secretName := environmentIngress.SecretName
 
@@ -449,7 +449,7 @@ func (r RawDataLogIngestorRepo) doDolittle(namespace string, customer k8s.Tenant
 	if input.Extra.WriteTo == "nats" {
 		stanClientID := "ingestor"
 		// TODO we hardcode nats
-		natsServer := fmt.Sprintf("%s-nats.%s.svc.cluster.local", environment, namespace)
+		natsServer := strings.ToLower(fmt.Sprintf("%s-nats.%s.svc.cluster.local", environment, namespace))
 		configEnvVariables.Data["NATS_SERVER"] = natsServer
 		configEnvVariables.Data["STAN_CLUSTER_ID"] = "stan"
 		configEnvVariables.Data["STAN_CLIENT_ID"] = stanClientID

--- a/pkg/platform/microservice/rawdatalog/repo.go
+++ b/pkg/platform/microservice/rawdatalog/repo.go
@@ -441,7 +441,7 @@ func (r RawDataLogIngestorRepo) doDolittle(namespace string, customer k8s.Tenant
 		"WEBHOOK_PREFIX":          webhookPrefix,
 		"DOLITTLE_TENANT_ID":      customer.ID,
 		"DOLITTLE_APPLICATION_ID": application.ID,
-		"DOLITTLE_ENVIRONMENT":    environment,
+		"DOLITTLE_ENVIRONMENT":    strings.ToLower(environment),
 		"MICROSERVICE_CONFIG":     "/app/data/microservice_data_from_studio.json",
 		"TOPIC":                   "purchaseorders",
 	}


### PR DESCRIPTION
## Summary

There was a bug in the raw data log ingestor repo implementation that converted the environment from the microservice from the input to lower case, causing the environment label on the raw data log deployment to be different from the other microservice kind deployments. 

However this fix has a side effect that I don't know the effects of, since we do not convert the environment to lower that results in the DOLITTLE_ENVIRONMENT environment variable on the envVariables config map being different (not lowercased). Is this important? If so we can just make the input there to lower case, that's not a big deal.
EDIT: As of writing this the code in question is on line 444


#### How to test
- Go through test steps in PR in Studio https://github.com/dolittle/Studio/pull/116

### Fixed

- Deployment of raw data log should now have the environment label in the proper casing
