### PR TITLE
Make STAN deployment persistent

### DIFF
--- a/cmd/rawdatalog/read-logs.go
+++ b/cmd/rawdatalog/read-logs.go
@@ -44,19 +44,19 @@ var readLogsCMD = &cobra.Command{
 		logrus.SetFormatter(&logrus.JSONFormatter{})
 
 		opts := []nats.Option{nats.Name("raw-data-log-reader")}
+		logContext := logrus.WithFields(logrus.Fields{
+			"context":    "raw-data-log-reader",
+			"cluster_id": clusterID,
+			"client_id":  clientID,
+		})
+		logContext.Info("Connecting to NATS Server...")
 		nc, err := nats.Connect(natsServer, opts...)
 
 		if err != nil {
 			panic(err)
 		}
 
-		logContext := logrus.WithFields(logrus.Fields{
-			"context":    "raw-data-log-reader",
-			"cluster_id": clusterID,
-			"client_id":  clientID,
-		})
-
-		logContext.Info("Connecting to nats server...")
+		logContext.Info("Connecting to NATS Streaming Server...")
 		sc, err := stan.Connect(clusterID, clientID,
 			stan.NatsConn(nc),
 			stan.SetConnectionLostHandler(func(_ stan.Conn, reason error) {

--- a/pkg/platform/microservice/rawdatalog/repo_test.go
+++ b/pkg/platform/microservice/rawdatalog/repo_test.go
@@ -509,7 +509,8 @@ var _ = Describe("Repo", func() {
 				streaming {
 					ns: "nats://loismay-nats:4222"
 					id: stan
-					store: MEMORY
+					store: file
+					dir: datastore
 				}
 			`))
 			})

--- a/pkg/rawdatalog/nats.go
+++ b/pkg/rawdatalog/nats.go
@@ -8,19 +8,20 @@ import (
 
 func SetupStan(logContext logrus.FieldLogger, natsServer string, clusterID string, clientID string) stan.Conn {
 	opts := []nats.Option{nats.Name("raw-data-log-writer")}
-	nc, err := nats.Connect(natsServer, opts...)
-
-	if err != nil {
-		panic(err)
-	}
-
 	logContext = logContext.WithFields(logrus.Fields{
 		"context":    "raw-data-log-writer",
 		"cluster_id": clusterID,
 		"client_id":  clientID,
 	})
 
-	logContext.Info("Connecting to nats server...")
+	logContext.Info("Connecting to NATS Server...")
+	nc, err := nats.Connect(natsServer, opts...)
+
+	if err != nil {
+		panic(err)
+	}
+
+	logContext.Info("Connecting to NATS Streaming Server...")
 	sc, err := stan.Connect(clusterID, clientID,
 		stan.NatsConn(nc),
 		stan.SetConnectionLostHandler(func(_ stan.Conn, reason error) {


### PR DESCRIPTION
## Summary

Adds a PersistentVolumeClaim to the STAN deployment with the name of `<env>-stan-storage` for the PVC. It uses the same [`managed-premium`](https://docs.microsoft.com/en-us/azure/aks/concepts-storage#storage-classes) storage class as we use for MongoDB in the platform. The STAN store method is [file](https://docs.nats.io/nats-streaming-server/configuring/persistence/file_store) and the name of the directory is `datastore` like in the STAN doc examples.

To use this locally you have to create a new storage class with the name `managed-premium`, create a persistent volume attached to it, and attach a directory to that persistent volume during k3d creation. This is documented in the Studio PR https://github.com/dolittle/Studio/pull/119

### Added

- Adds a PersistentVolumeClaim of 8GB to the STAN deployment

### Changed

- Made some logging around NATS/STAN creation more clear in RawDataLog