### PR TITLE
Don't write microservice object if error occured

### DIFF
--- a/pkg/platform/microservice/service.go
+++ b/pkg/platform/microservice/service.go
@@ -111,6 +111,7 @@ func (s *service) Create(responseWriter http.ResponseWriter, request *http.Reque
 		purchaseOrderAPI, err := s.purchaseOrderHandler.Create(requestBytes, applicationInfo)
 		if err != nil {
 			utils.RespondWithError(responseWriter, err.StatusCode, err.Error())
+			break
 		}
 		utils.RespondWithJSON(responseWriter, http.StatusAccepted, purchaseOrderAPI)
 	default:


### PR DESCRIPTION
## Summary

Fixes a bug where if an error occurs during creation of a PurchaseOrderAPI microservice, both the error object and the microservice object was written to the response. Resulting in invalid JSON in the response body.

### Fixed

- Don't append the microservice object to the response body if an error occurs during creation of a PurchaseOrderAPI
