### PR TITLE
Add new endpoint for serving the status of PurchaseOrderAPI

### DIFF
--- a/cmd/microservice/server.go
+++ b/cmd/microservice/server.go
@@ -14,6 +14,8 @@ import (
 	"github.com/dolittle-entropy/platform-api/pkg/platform/businessmoment"
 	"github.com/dolittle-entropy/platform-api/pkg/platform/insights"
 	"github.com/dolittle-entropy/platform-api/pkg/platform/microservice"
+	"github.com/dolittle-entropy/platform-api/pkg/platform/microservice/purchaseorderapi"
+	"github.com/dolittle-entropy/platform-api/pkg/platform/microservice/rawdatalog"
 
 	gitStorage "github.com/dolittle-entropy/platform-api/pkg/platform/storage/git"
 	"github.com/dolittle-entropy/platform-api/pkg/platform/tenant"
@@ -130,6 +132,7 @@ var serverCMD = &cobra.Command{
 
 		router.Handle("/application/{applicationID}/environment/{environment}/microservice/{microserviceID}", stdChainWithJSON.ThenFunc(microserviceService.GetByID)).Methods(http.MethodGet, http.MethodOptions)
 		router.Handle("/application/{applicationID}/environment/{environment}/microservice/{microserviceID}", stdChainWithJSON.ThenFunc(microserviceService.Delete)).Methods(http.MethodDelete, http.MethodOptions)
+		router.Handle("/application/{applicationID}/environment/{environment}/microservice/{microserviceID}/kind/{kind}/status", stdChainBase.Then(microserviceService.GetStatus)).Methods(http.MethodGet, http.MethodOptions)
 
 		router.Handle("/live/applications", stdChainWithJSON.ThenFunc(applicationService.GetLiveApplications)).Methods(http.MethodGet, http.MethodOptions)
 		router.Handle("/live/application/{applicationID}/microservices", stdChainWithJSON.ThenFunc(microserviceService.GetLiveByApplicationID)).Methods(http.MethodGet, http.MethodOptions)

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -374,3 +374,6 @@ type RuntimeStateFailingPartition struct {
 	Reason             string `json:"reason"`
 	RetryTime          string `json:"retryTime"`
 }
+
+type PurchaseOrderStatus struct {
+}


### PR DESCRIPTION
## Summary

Adds a new API endpoint `/application/{applicationID}/environment/{environment}/microservice/{microserviceID}/kind/purchase-order-api/status` for fetching the current status of PurchaseOrderAPI through it's own API (related PR https://github.com/dolittle/ERPIntegrations/pull/37). The received payload looks like this:

```json
{"status":"Running","lastReceivedPayload":"2021-10-05T15:52:18.795Z","error":""}
```

### Added

- New API endpoint `/application/{applicationID}/environment/{environment}/microservice/{microserviceID}/kind/purchase-order-api/status` for fetching the status of a PurchaseOrderMicroservice.