### PR TITLE
Add ability to create a base microservice without a Runtime container

### DIFF
--- a/pkg/dolittle/k8s/deployment.go
+++ b/pkg/dolittle/k8s/deployment.go
@@ -6,6 +6,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -174,6 +175,14 @@ func NewDeployment(microservice Microservice, headImage string, runtimeImage str
 }
 
 func Runtime(image string) apiv1.Container {
+	limit, err := resource.ParseQuantity("1Gi")
+	if err != nil {
+		panic(err)
+	}
+	request, err := resource.ParseQuantity("250Mi")
+	if err != nil {
+		panic(err)
+	}
 	return apiv1.Container{
 		Name:  "runtime",
 		Image: image,
@@ -182,6 +191,14 @@ func Runtime(image string) apiv1.Container {
 				Name:          "runtime",
 				Protocol:      apiv1.ProtocolTCP,
 				ContainerPort: 50052,
+			},
+		},
+		Resources: apiv1.ResourceRequirements{
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceMemory: limit,
+			},
+			Requests: apiv1.ResourceList{
+				apiv1.ResourceMemory: request,
 			},
 		},
 		VolumeMounts: []apiv1.VolumeMount{

--- a/pkg/dolittle/k8s/deployment.go
+++ b/pkg/dolittle/k8s/deployment.go
@@ -48,11 +48,64 @@ func NewDeployment(microservice Microservice, headImage string, runtimeImage str
 	configEnvVariablesName = strings.ToLower(configEnvVariablesName)
 	configSecretEnvVariablesName = strings.ToLower(configSecretEnvVariablesName)
 
-	//envFrom:
-	//        - configMapRef:
-	//            name: dev-excelsior-env-variables
-	//        - secretRef:
-	//            name: dev-excelsior-secret-env-variables
+	containers := []apiv1.Container{
+		{
+			Name:  "head",
+			Image: headImage,
+			Ports: []apiv1.ContainerPort{
+				{
+					Name:          "http",
+					Protocol:      apiv1.ProtocolTCP,
+					ContainerPort: 80,
+				},
+			},
+			EnvFrom: []apiv1.EnvFromSource{
+				{
+					ConfigMapRef: &apiv1.ConfigMapEnvSource{
+						LocalObjectReference: apiv1.LocalObjectReference{
+							Name: configEnvVariablesName,
+						},
+					},
+				},
+				{
+					SecretRef: &apiv1.SecretEnvSource{
+						LocalObjectReference: apiv1.LocalObjectReference{
+							Name: configSecretEnvVariablesName,
+						},
+					},
+				},
+			},
+			VolumeMounts: []apiv1.VolumeMount{
+				{
+					MountPath: "/app/.dolittle/tenants.json",
+					SubPath:   "tenants.json",
+					Name:      "tenants-config",
+				},
+				{
+					MountPath: "/app/.dolittle/resources.json",
+					SubPath:   "resources.json",
+					Name:      "dolittle-config",
+				},
+				{
+					MountPath: "/app/.dolittle/clients.json",
+					SubPath:   "clients.json",
+					Name:      "dolittle-config",
+				},
+				{
+					MountPath: "/app/.dolittle/event-horizons.json",
+					SubPath:   "event-horizons.json",
+					Name:      "dolittle-config",
+				},
+				{
+					MountPath: "/app/data",
+					Name:      "config-files",
+				},
+			},
+		},
+	}
+	if runtimeImage != "none" {
+		containers = append(containers, Runtime(runtimeImage))
+	}
 
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -79,62 +132,7 @@ func NewDeployment(microservice Microservice, headImage string, runtimeImage str
 					ImagePullSecrets: []apiv1.LocalObjectReference{
 						{"acr"},
 					},
-					Containers: []apiv1.Container{
-						{
-							Name:  "head",
-							Image: headImage,
-							Ports: []apiv1.ContainerPort{
-								{
-									Name:          "http",
-									Protocol:      apiv1.ProtocolTCP,
-									ContainerPort: 80,
-								},
-							},
-							EnvFrom: []apiv1.EnvFromSource{
-								{
-									ConfigMapRef: &apiv1.ConfigMapEnvSource{
-										LocalObjectReference: apiv1.LocalObjectReference{
-											Name: configEnvVariablesName,
-										},
-									},
-								},
-								{
-									SecretRef: &apiv1.SecretEnvSource{
-										LocalObjectReference: apiv1.LocalObjectReference{
-											Name: configSecretEnvVariablesName,
-										},
-									},
-								},
-							},
-							VolumeMounts: []apiv1.VolumeMount{
-								{
-									MountPath: "/app/.dolittle/tenants.json",
-									SubPath:   "tenants.json",
-									Name:      "tenants-config",
-								},
-								{
-									MountPath: "/app/.dolittle/resources.json",
-									SubPath:   "resources.json",
-									Name:      "dolittle-config",
-								},
-								{
-									MountPath: "/app/.dolittle/clients.json",
-									SubPath:   "clients.json",
-									Name:      "dolittle-config",
-								},
-								{
-									MountPath: "/app/.dolittle/event-horizons.json",
-									SubPath:   "event-horizons.json",
-									Name:      "dolittle-config",
-								},
-								{
-									MountPath: "/app/data",
-									Name:      "config-files",
-								},
-							},
-						},
-						Runtime(runtimeImage),
-					},
+					Containers: containers,
 					Volumes: []apiv1.Volume{
 						{
 							Name: "tenants-config",

--- a/pkg/platform/microservice/simple_repo.go
+++ b/pkg/platform/microservice/simple_repo.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dolittle/platform-api/pkg/platform"
 	. "github.com/dolittle/platform-api/pkg/platform/microservice/k8s"
 	networkingv1 "k8s.io/api/networking/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
@@ -27,8 +27,6 @@ func NewSimpleRepo(k8sClient kubernetes.Interface) simpleRepo {
 }
 
 func (r simpleRepo) Create(namespace string, tenant k8s.Tenant, application k8s.Application, applicationIngress k8s.Ingress, input platform.HttpInputSimpleInfo) error {
-	// TODO not sure where this comes from really, assume dynamic
-
 	environment := input.Environment
 	host := applicationIngress.Host
 	secretName := applicationIngress.SecretName
@@ -75,42 +73,42 @@ func (r simpleRepo) Create(namespace string, tenant k8s.Tenant, application k8s.
 	client := r.k8sClient
 	ctx := context.TODO()
 
-	_, err = client.CoreV1().ConfigMaps(namespace).Create(ctx, microserviceConfigmap, metaV1.CreateOptions{})
+	_, err = client.CoreV1().ConfigMaps(namespace).Create(ctx, microserviceConfigmap, metav1.CreateOptions{})
 	if K8sHandleResourceCreationError(err, func() { K8sPrintAlreadyExists("microservice config map") }) != nil {
 		return err
 	}
 
-	_, err = client.CoreV1().ConfigMaps(namespace).Create(ctx, configEnvVariables, metaV1.CreateOptions{})
+	_, err = client.CoreV1().ConfigMaps(namespace).Create(ctx, configEnvVariables, metav1.CreateOptions{})
 	if K8sHandleResourceCreationError(err, func() { K8sPrintAlreadyExists("config env variables") }) != nil {
 		return err
 	}
 
-	_, err = client.CoreV1().ConfigMaps(namespace).Create(ctx, configFiles, metaV1.CreateOptions{})
+	_, err = client.CoreV1().ConfigMaps(namespace).Create(ctx, configFiles, metav1.CreateOptions{})
 	if K8sHandleResourceCreationError(err, func() { K8sPrintAlreadyExists("config files") }) != nil {
 		return err
 	}
 
-	_, err = client.CoreV1().Secrets(namespace).Create(ctx, configSecrets, metaV1.CreateOptions{})
+	_, err = client.CoreV1().Secrets(namespace).Create(ctx, configSecrets, metav1.CreateOptions{})
 	if K8sHandleResourceCreationError(err, func() { K8sPrintAlreadyExists("config secrets") }) != nil {
 		return err
 	}
 
-	_, err = client.NetworkingV1().Ingresses(namespace).Create(ctx, ingress, metaV1.CreateOptions{})
+	_, err = client.NetworkingV1().Ingresses(namespace).Create(ctx, ingress, metav1.CreateOptions{})
 	if K8sHandleResourceCreationError(err, func() { K8sPrintAlreadyExists("ingress") }) != nil {
 		return err
 	}
 
-	_, err = client.NetworkingV1().NetworkPolicies(namespace).Create(ctx, networkPolicy, metaV1.CreateOptions{})
+	_, err = client.NetworkingV1().NetworkPolicies(namespace).Create(ctx, networkPolicy, metav1.CreateOptions{})
 	if K8sHandleResourceCreationError(err, func() { K8sPrintAlreadyExists("network policy") }) != nil {
 		return err
 	}
 
-	_, err = client.CoreV1().Services(namespace).Create(ctx, service, metaV1.CreateOptions{})
+	_, err = client.CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 	if K8sHandleResourceCreationError(err, func() { K8sPrintAlreadyExists("service") }) != nil {
 		return err
 	}
 
-	_, err = client.AppsV1().Deployments(namespace).Create(ctx, deployment, metaV1.CreateOptions{})
+	_, err = client.AppsV1().Deployments(namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	if K8sHandleResourceCreationError(err, func() { K8sPrintAlreadyExists("deployment") }) != nil {
 		return err
 	}
@@ -131,7 +129,7 @@ func (r simpleRepo) Delete(namespace string, microserviceID string) error {
 	}
 
 	// Selector information for microservice, based on labels
-	listOpts := metaV1.ListOptions{
+	listOpts := metav1.ListOptions{
 		LabelSelector: labels.FormatLabels(deployment.GetObjectMeta().GetLabels()),
 	}
 


### PR DESCRIPTION
## Summary

Add's the ability to create a base microservice without a Runtime container by defining the wanted Runtime image as `"none"` in the request.

Also adds memory limits to newly created Runtime containers in a microservice. The request is for 250MB and the limit is 1GB.

Related to https://github.com/dolittle/Studio/pull/136
