### PR TITLE
Public url for microservices in the platform but not in studio

### DIFF
--- a/pkg/platform/application/service.go
+++ b/pkg/platform/application/service.go
@@ -247,10 +247,16 @@ func (s *service) GetByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	microservices, err := s.gitRepo.GetMicroservices(tenantID, applicationID)
-	utils.RespondWithJSON(w, http.StatusOK, platform.HttpResponseApplication2{
+	if err != nil {
+		utils.RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	utils.RespondWithJSON(w, http.StatusOK, platform.HttpResponseApplication{
 		ID:            application.ID,
 		Name:          application.Name,
 		TenantID:      application.TenantID,
+		TenantName:    application.TenantName,
 		Environments:  application.Environments,
 		Microservices: microservices,
 	})

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -1,6 +1,10 @@
 package platform
 
-import "errors"
+import (
+	"errors"
+
+	networkingv1 "k8s.io/api/networking/v1"
+)
 
 type Microservice interface {
 	GetBase() MicroserviceBase
@@ -71,11 +75,13 @@ type ContainerStatusInfo struct {
 }
 
 type MicroserviceInfo struct {
-	Name        string      `json:"name"`
-	Environment string      `json:"environment"`
-	ID          string      `json:"id"`
-	Images      []ImageInfo `json:"images"`
-	Kind        string      `json:"kind"`
+	Name         string                           `json:"name"`
+	Environment  string                           `json:"environment"`
+	ID           string                           `json:"id"`
+	Images       []ImageInfo                      `json:"images"`
+	Kind         string                           `json:"kind"`
+	IngressURLS  []IngressURLWithCustomerTenantID `json:"ingressUrls"`
+	IngressPaths []networkingv1.HTTPIngressPath   `json:"ingressPaths"`
 }
 type PodInfo struct {
 	Name       string                `json:"name"`
@@ -372,4 +378,9 @@ type PurchaseOrderStatus struct {
 	Status              string `json:"status"`
 	LastReceivedPayload string `json:"lastReceivedPayload"`
 	Error               string `json:"error"`
+}
+
+type IngressURLWithCustomerTenantID struct {
+	URL              string `json:"url"`
+	CustomerTenantID string `json:"customerTenantID"`
 }

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -41,20 +41,13 @@ type HttpInputEnvironment struct {
 	Ingresses         EnvironmentIngresses `json:"ingresses"`
 }
 
-type HttpResponseApplication2 struct {
+type HttpResponseApplication struct {
 	ID            string                 `json:"id"`
 	Name          string                 `json:"name"`
 	TenantID      string                 `json:"tenantId"`
+	TenantName    string                 `json:"tenantName"`
 	Environments  []HttpInputEnvironment `json:"environments"`
-	Microservices []HttpMicroserviceBase `json:"microservices"`
-}
-
-type HttpResponseApplication struct {
-	ID           string                 `json:"id"`
-	Name         string                 `json:"name"`
-	TenantID     string                 `json:"tenantId"`
-	TenantName   string                 `json:"tenantName"`
-	Environments []HttpInputEnvironment `json:"environments"`
+	Microservices []HttpMicroserviceBase `json:"microservices,omitempty"`
 }
 
 type HttpResponseApplications struct {

--- a/pkg/platform/k8s_repo.go
+++ b/pkg/platform/k8s_repo.go
@@ -3,7 +3,6 @@ package platform
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -736,10 +735,8 @@ func (r *K8sRepo) GetIngressHTTPIngressPath(applicationID string, environment st
 				// For now, there is no need to expose it
 				rulePath.Backend = networkingv1.IngressBackend{}
 
-				diffA, _ := json.Marshal(rulePath)
 				exists := funk.Contains(items, func(item networkingv1.HTTPIngressPath) bool {
-					diffB, _ := json.Marshal(item)
-					return string(diffA) == string(diffB)
+					return rulePath == item
 				})
 
 				if exists {

--- a/pkg/platform/k8s_repo.go
+++ b/pkg/platform/k8s_repo.go
@@ -710,6 +710,7 @@ func (r *K8sRepo) GetIngressURLsWithCustomerTenantID(applicationID string, envir
 	return urls, nil
 }
 
+// GetIngressHTTPIngressPath Return unique Ingress Paths
 func (r *K8sRepo) GetIngressHTTPIngressPath(applicationID string, environment string, microserviceID string) ([]networkingv1.HTTPIngressPath, error) {
 	client := r.k8sClient
 	ctx := context.TODO()

--- a/pkg/platform/k8s_repo_test.go
+++ b/pkg/platform/k8s_repo_test.go
@@ -1,0 +1,21 @@
+package platform_test
+
+import (
+	"regexp"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("k8s repo test", func() {
+	When("Working with the Ingress", func() {
+		FIt("Get the Customer TenantID from nginx configuration", func() {
+			sample := `proxy_set_header Tenant-ID "61838650-f8b7-412f-8e46-dc6165fc3dc4";`
+			r, _ := regexp.Compile(`proxy_set_header Tenant-ID "(\S+)"`)
+
+			matches := r.FindStringSubmatch(sample)
+			Expect(len(matches)).To(Equal(2))
+			Expect(matches[1]).To(Equal("61838650-f8b7-412f-8e46-dc6165fc3dc4"))
+		})
+	})
+})

--- a/pkg/platform/k8s_repo_test.go
+++ b/pkg/platform/k8s_repo_test.go
@@ -1,21 +1,27 @@
 package platform_test
 
 import (
-	"regexp"
-
+	"github.com/dolittle/platform-api/pkg/platform"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("k8s repo test", func() {
 	When("Working with the Ingress", func() {
-		FIt("Get the Customer TenantID from nginx configuration", func() {
-			sample := `proxy_set_header Tenant-ID "61838650-f8b7-412f-8e46-dc6165fc3dc4";`
-			r, _ := regexp.Compile(`proxy_set_header Tenant-ID "(\S+)"`)
+		When("Get the Customer TenantID from nginx configuration", func() {
+			It("Not found", func() {
+				sample := `nothing`
+				expect := ""
+				customerTenantID := platform.GetCustomerTenantIDFromNginxConfigurationSnippet(sample)
+				Expect(customerTenantID).To(Equal(expect))
 
-			matches := r.FindStringSubmatch(sample)
-			Expect(len(matches)).To(Equal(2))
-			Expect(matches[1]).To(Equal("61838650-f8b7-412f-8e46-dc6165fc3dc4"))
+			})
+			It("Found", func() {
+				sample := `proxy_set_header Tenant-ID "61838650-f8b7-412f-8e46-dc6165fc3dc4";`
+				expect := "61838650-f8b7-412f-8e46-dc6165fc3dc4"
+				customerTenantID := platform.GetCustomerTenantIDFromNginxConfigurationSnippet(sample)
+				Expect(customerTenantID).To(Equal(expect))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Rename HttpResponseApplications2 to HttpResponseApplication
- Expose the Ingress host + path per customer Tenant ID
- Expose Unique Ingress Paths (microservice paths)