### PR TITLE
Add script for adding tenants to resources.json

### DIFF
--- a/cmd/tools/add-tenants-to-resources.go
+++ b/cmd/tools/add-tenants-to-resources.go
@@ -1,0 +1,164 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+	// "k8s.io/apimachinery/pkg/runtime"
+	// k8sJson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+type dolittleConfig struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Annotations struct {
+			DolittleIoTenantID       string `yaml:"dolittle.io/tenant-id"`
+			DolittleIoApplicationID  string `yaml:"dolittle.io/application-id"`
+			DolittleIoMicroserviceID string `yaml:"dolittle.io/microservice-id"`
+		} `yaml:"annotations"`
+		Labels struct {
+			Tenant       string `yaml:"tenant"`
+			Application  string `yaml:"application"`
+			Environment  string `yaml:"environment"`
+			Microservice string `yaml:"microservice"`
+		} `yaml:"labels"`
+		Name      string `yaml:"name"`
+		Namespace string `yaml:"namespace"`
+	} `yaml:"metadata"`
+	Data struct {
+		ResourcesJSON            string `yaml:"resources.json"`
+		EventHorizonsJSON        string `yaml:"event-horizons.json"`
+		EventHorizonConsentsJSON string `yaml:"event-horizon-consents.json"`
+		MicroservicesJSON        string `yaml:"microservices.json"`
+		EndpointsJSON            string `yaml:"endpoints.json"`
+		AppsettingsJSON          string `yaml:"appsettings.json"`
+	} `yaml:"data"`
+}
+
+type resourceJSON map[string]tenantResource
+
+type tenantResource struct {
+	ReadModels ReadModels `json:"readModels"`
+	EventStore EventStore `json:"eventStore"`
+}
+type ReadModels struct {
+	Host     string `json:"host"`
+	Database string `json:"database"`
+	UseSSL   bool   `json:"useSSL"`
+}
+type EventStore struct {
+	Servers               []string `json:"servers"`
+	Database              string   `json:"database"`
+	MaxConnectionPoolSize int      `json:"maxConnectionPoolSize"`
+}
+
+var addTenantsToResourcesCMD = &cobra.Command{
+	Use:   "add-tenants-to-resources",
+	Short: "Adds a new tenant to a microservices k8s resource file",
+	Long: `
+	
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		// runtimeScheme := runtime.NewScheme()
+		// serializer := k8sJson.NewSerializerWithOptions(
+		// 	k8sJson.DefaultMetaFactory,
+		// 	runtimeScheme,
+		// 	runtimeScheme,
+		// 	k8sJson.SerializerOptions{
+		// 		Yaml:   true,
+		// 		Pretty: true,
+		// 		Strict: true,
+		// 	},
+		// )
+
+		if len(args) == 0 {
+			fmt.Println("You have to provide a filename")
+			return
+		}
+		fileName := args[0]
+
+		data, err := os.ReadFile(fileName)
+		if err != nil {
+			fmt.Println("Couldn't read file")
+			panic(err)
+		}
+
+		config := &dolittleConfig{}
+		err = yaml.Unmarshal(data, config)
+		if err != nil {
+			fmt.Println("Couldn't unmarshal yaml file")
+			panic(err)
+		}
+
+		microserviceID := config.Metadata.Annotations.DolittleIoMicroserviceID[0:8]
+
+		resourcesJson := make(resourceJSON)
+
+		err = json.Unmarshal([]byte(config.Data.ResourcesJSON), &resourcesJson)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("There's %v tenant(s) \n", len(resourcesJson))
+
+		var dbHost string
+		// get the first host from the resources.json
+		for _, value := range resourcesJson {
+			dbHost = value.EventStore.Servers[0]
+			break
+		}
+
+		for i := 0; i < 9; i++ {
+
+			newTenant := uuid.New().String()
+
+			newDatabase := fmt.Sprintf("%s_%s", microserviceID, newTenant[0:8])
+
+			readmodels := fmt.Sprintf("%s_readmodels", newDatabase)
+			eventstore := fmt.Sprintf("%s_eventstore", newDatabase)
+
+			resourcesJson[newTenant] = tenantResource{
+				ReadModels: ReadModels{
+					Host:     fmt.Sprintf("mongodb://%s:27017", dbHost),
+					Database: readmodels,
+					UseSSL:   false,
+				},
+				EventStore: EventStore{
+					Servers: []string{
+						dbHost,
+					},
+					Database:              eventstore,
+					MaxConnectionPoolSize: 2000,
+				},
+			}
+
+			fmt.Printf("TenantID: %s Database: %s Eventstore: %s\n", newTenant, readmodels, eventstore)
+		}
+		fmt.Printf("Added new tenant(s), new amount of tenants is %v\n", len(resourcesJson))
+
+		resourcesJsonString, err := json.MarshalIndent(resourcesJson, "", "  ")
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println("Here's the new resources.json, copy and paste it:")
+		fmt.Println(string(resourcesJsonString))
+		// config.Data.ResourcesJSON = string(resourcesJsonString)
+
+		// newYaml, err := yaml.Marshal(config)
+		// if err != nil {
+		// 	panic(err)
+		// }
+
+		// fmt.Println("printing the new yaml")
+		// fmt.Println(string(newYaml))
+
+		// serializer.Encode(config, os.Stdout)
+	},
+}

--- a/cmd/tools/root.go
+++ b/cmd/tools/root.go
@@ -14,4 +14,5 @@ Tools to interact with the platform`,
 
 func init() {
 	RootCmd.AddCommand(createCustomerHclCMD)
+	RootCmd.AddCommand(addTenantsToResourcesCMD)
 }

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34 // indirect
 	golang.org/x/text v0.3.7 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/api v0.20.4
 	k8s.io/apimachinery v0.20.4
 	k8s.io/client-go v0.20.4


### PR DESCRIPTION
## Summary

Add's a simple script for reading a `microservice.yml` file, adding new tenants to the `resource.json` and outputting the `resource.json` into the terminal for copy-pastining it back into the `microservice.yml` file.