### PR TITLE
Fix getServiceAccountCredentials to return the whole k8s Secret resource

### DIFF
--- a/pkg/platform/cicd/service.go
+++ b/pkg/platform/cicd/service.go
@@ -70,7 +70,7 @@ func (s *service) getServiceAccountCredentials(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	utils.RespondWithJSON(w, http.StatusOK, secret.Data)
+	utils.RespondWithJSON(w, http.StatusOK, secret)
 }
 
 func (s *service) GetContainerRegistryCredentials(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Fixes the `getServiceAccountCredentials()` method to return the whole k8s Secret resource. This is because Azure DevOps requires the whole Secret resource instead of just the data part when setting up a kubernetes connection.

The Studio button that calls this endpoint:
![image](https://user-images.githubusercontent.com/10163775/150506082-c26b1701-4f4f-481b-8af4-8021e3a52d66.png)
