### PR TITLE
Make `GetDeployment` environment aware

### DIFF
--- a/cmd/tools/automate/add-platform-config.go
+++ b/cmd/tools/automate/add-platform-config.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 
 	configK8s "github.com/dolittle/platform-api/pkg/dolittle/k8s"
@@ -163,8 +162,7 @@ func addPlatformDataToMicroservice(ctx context.Context, client kubernetes.Interf
 		}).Fatal("Failed to update configmap")
 	}
 
-	namespace := fmt.Sprintf("application-%s", applicationID)
-	deployment, err := automate.GetDeployment(ctx, client, namespace, microserviceID)
+	deployment, err := automate.GetDeployment(ctx, client, applicationID, environment, microserviceID)
 	if err != nil {
 		logContext.WithFields(logrus.Fields{
 			"error": err,

--- a/pkg/platform/microservice/businessmomentsadaptor_repo.go
+++ b/pkg/platform/microservice/businessmomentsadaptor_repo.go
@@ -176,13 +176,14 @@ func (r businessMomentsAdaptorRepo) Create(namespace string, tenant k8s.Tenant, 
 	return nil
 }
 
-func (r businessMomentsAdaptorRepo) Delete(namespace string, microserviceID string) error {
+func (r businessMomentsAdaptorRepo) Delete(applicationID, environment, microserviceID string) error {
 	ctx := context.TODO()
-	deployment, err := automate.GetDeployment(ctx, r.k8sClient, namespace, microserviceID)
+	deployment, err := automate.GetDeployment(ctx, r.k8sClient, applicationID, environment, microserviceID)
 	if err != nil {
 		return err
 	}
 
+	namespace := fmt.Sprintf("application-%s", applicationID)
 	if err = K8sStopDeployment(r.k8sClient, ctx, namespace, &deployment); err != nil {
 		return err
 	}

--- a/pkg/platform/microservice/purchaseorderapi/doc.go
+++ b/pkg/platform/microservice/purchaseorderapi/doc.go
@@ -13,7 +13,7 @@ type Repo interface {
 	// Create creates the microservice by committing it to a persistent storage and applying its kubernetes resources
 	Create(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) error
 	// Delete deletes the microservice by deleting its kubernetes resources
-	Delete(namespace, microserviceID string) error
+	Delete(applicationID, environment, microserviceID string) error
 	// Exists checks whether a purchase order api with the same name has already been created
 	Exists(namespace string, customer k8s.Tenant, application k8s.Application, tenant platform.TenantId, input platform.HttpInputPurchaseOrderInfo) (bool, error)
 	// EnvironmentHasPurchaseOrderAPI checks whether the given environment has a purchase order api deployed
@@ -22,7 +22,7 @@ type Repo interface {
 
 type K8sResource interface {
 	Create(namspace, headImage, runtimeImage string, k8sMicroservice k8s.Microservice, tenant platform.TenantId, extra platform.HttpInputPurchaseOrderExtra, ctx context.Context) error
-	Delete(namespace, microserviceID string, ctx context.Context) error
+	Delete(applicationID, environment, microserviceID string, ctx context.Context) error
 }
 type K8sResourceSpecFactory interface {
 	CreateAll(headImage, runtimeImage string, k8sMicroservice k8s.Microservice, tenant platform.TenantId, extra platform.HttpInputPurchaseOrderExtra) K8sResources

--- a/pkg/platform/microservice/purchaseorderapi/handler.go
+++ b/pkg/platform/microservice/purchaseorderapi/handler.go
@@ -140,8 +140,8 @@ func (s *Handler) UpdateWebhooks(inputBytes []byte, applicationInfo platform.App
 	return ms, s.updatePurchaseOrderAPIWebhooks(msK8sInfo, ms.Extra.Webhooks, ms.Environment, ms.Dolittle.MicroserviceID, logger)
 }
 
-func (s *Handler) Delete(namespace, microserviceID string) error {
-	if err := s.repo.Delete(namespace, microserviceID); err != nil {
+func (s *Handler) Delete(applicationID, environment, microserviceID string) error {
+	if err := s.repo.Delete(applicationID, environment, microserviceID); err != nil {
 		return fmt.Errorf("failed to delete Purchase Order API: %w", err)
 	}
 	return nil

--- a/pkg/platform/microservice/purchaseorderapi/k8sResource.go
+++ b/pkg/platform/microservice/purchaseorderapi/k8sResource.go
@@ -2,6 +2,7 @@ package purchaseorderapi
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dolittle/platform-api/pkg/dolittle/k8s"
 	"github.com/dolittle/platform-api/pkg/platform"
@@ -62,21 +63,23 @@ func (r *k8sResource) Create(namespace, headImage, runtimeImage string, k8sMicro
 }
 
 // Delete stops the running purchase order api and deletes the kubernetes resources.
-func (r *k8sResource) Delete(namespace, microserviceID string, ctx context.Context) error {
-	deployment, err := r.getAndStopDeployment(ctx, namespace, microserviceID)
+func (r *k8sResource) Delete(applicationID, environment, microserviceID string, ctx context.Context) error {
+	deployment, err := r.getAndStopDeployment(ctx, applicationID, environment, microserviceID)
 	if err != nil {
 		return err
 	}
 
+	namespace := fmt.Sprintf("application-%s", applicationID)
 	return r.deleteResources(ctx, namespace, deployment)
 }
 
-func (r *k8sResource) getAndStopDeployment(ctx context.Context, namespace, microserviceID string) (v1.Deployment, error) {
-	deployment, err := automate.GetDeployment(ctx, r.k8sClient, namespace, microserviceID)
+func (r *k8sResource) getAndStopDeployment(ctx context.Context, applicationID, environment, microserviceID string) (v1.Deployment, error) {
+	deployment, err := automate.GetDeployment(ctx, r.k8sClient, applicationID, environment, microserviceID)
 	if err != nil {
 		return deployment, err
 	}
 
+	namespace := fmt.Sprintf("application-%s", applicationID)
 	if err = microserviceK8s.K8sStopDeployment(r.k8sClient, ctx, namespace, &deployment); err != nil {
 		return deployment, err
 	}

--- a/pkg/platform/microservice/purchaseorderapi/repo.go
+++ b/pkg/platform/microservice/purchaseorderapi/repo.go
@@ -106,7 +106,7 @@ func (r *repo) EnvironmentHasPurchaseOrderAPI(namespace string, input platform.H
 }
 
 // Delete stops the running purchase order api and deletes the kubernetes resources.
-func (r *repo) Delete(namespace string, microserviceID string) error {
+func (r *repo) Delete(applicationID, environment, microserviceID string) error {
 	ctx := context.TODO()
-	return r.k8sResource.Delete(namespace, microserviceID, ctx)
+	return r.k8sResource.Delete(applicationID, environment, microserviceID, ctx)
 }

--- a/pkg/platform/microservice/rawdatalog/repo.go
+++ b/pkg/platform/microservice/rawdatalog/repo.go
@@ -212,6 +212,9 @@ func (r RawDataLogIngestorRepo) Delete(namespace string, microserviceID string) 
 			continue
 		}
 
+		// TODO microservice-id isn't unique, it can be shared by microservices accoss environments sadly
+		// so this should also check for the correct environment to be 100% sure
+		// it probably doesn't matter too much for RawDataLogIngerstorRepo currently
 		if deployment.ObjectMeta.Annotations["dolittle.io/microservice-id"] == microserviceID {
 			found = true
 			foundDeployment = deployment

--- a/pkg/platform/microservice/service.go
+++ b/pkg/platform/microservice/service.go
@@ -326,13 +326,13 @@ func (s *service) Delete(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			switch whatKind.Kind {
 			case platform.MicroserviceKindSimple:
-				err = s.simpleRepo.Delete(namespace, microserviceID)
+				err = s.simpleRepo.Delete(applicationID, environment, microserviceID)
 			case platform.MicroserviceKindBusinessMomentsAdaptor:
-				err = s.businessMomentsAdaptorRepo.Delete(namespace, microserviceID)
+				err = s.businessMomentsAdaptorRepo.Delete(applicationID, environment, microserviceID)
 			case platform.MicroserviceKindRawDataLogIngestor:
 				err = s.rawDataLogIngestorRepo.Delete(namespace, microserviceID)
 			case platform.MicroserviceKindPurchaseOrderAPI:
-				err = s.purchaseOrderHandler.Delete(namespace, microserviceID)
+				err = s.purchaseOrderHandler.Delete(applicationID, environment, microserviceID)
 			}
 			if err != nil {
 				statusCode = http.StatusUnprocessableEntity

--- a/pkg/platform/microservice/simple_repo.go
+++ b/pkg/platform/microservice/simple_repo.go
@@ -117,14 +117,15 @@ func (r simpleRepo) Create(namespace string, tenant k8s.Tenant, application k8s.
 	return nil
 }
 
-func (r simpleRepo) Delete(namespace string, microserviceID string) error {
+func (r simpleRepo) Delete(applicationID, environment, microserviceID string) error {
 	ctx := context.TODO()
 
-	deployment, err := automate.GetDeployment(ctx, r.k8sClient, namespace, microserviceID)
+	deployment, err := automate.GetDeployment(ctx, r.k8sClient, applicationID, environment, microserviceID)
 	if err != nil {
 		return err
 	}
 
+	namespace := fmt.Sprintf("application-%s", applicationID)
 	if err = K8sStopDeployment(r.k8sClient, ctx, namespace, &deployment); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Changes the `GetDeployment` function to require `applicationID` & `environment` instead of just a `namespace`. This is because some microservices reuse the same microserviceID accross environment. This makes it so that you can reliably always get the correct deployment from the correct environment.