### PR TITLE
Fix Makefile server script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ server:
 	LISTEN_ON="localhost:8081" \
 	HEADER_SECRET="FAKE" \
 	AZURE_SUBSCRIPTION_ID="e7220048-8a2c-4537-994b-6f9b320692d7" \
-	go run main.go microservice server
+	go run main.go api server
 
 docker-build-dev-platform-api:
 	docker build -f ./Dockerfile -t dolittle-dev/platform-api:latest .


### PR DESCRIPTION
## Summary
Fix Makefile server script - Replace 'microservice' with 'api'

### Fixed

- Fix Makefile server script - Replace 'microservice' with 'api'
