### PR TITLE
Add support for V8 Runtime with backwards compatibility set to V7 by default

### DIFF
--- a/pkg/dolittle/k8s/configmaps.go
+++ b/pkg/dolittle/k8s/configmaps.go
@@ -84,19 +84,19 @@ type AppsettingsLogging struct {
 
 type AppsettingsV8_0_0 struct {
 	Appsettings
-	dolittle dolittle `json:"dolittle"`
+	Dolittle dolittle `json:"dolittle"`
 }
 type dolittle struct {
-	runtime runtime `json:"runtime"`
+	Runtime runtime `json:"runtime"`
 }
 type runtime struct {
-	eventStore eventStore `json:"eventstore"`
+	EventStore eventStore `json:"eventstore"`
 }
 type eventStore struct {
-	backwardsCompatibility backwardsCompatibility `json:"backwardscompatibility"`
+	BackwardsCompatibility backwardsCompatibility `json:"backwardscompatibility"`
 }
 type backwardsCompatibility struct {
-	version BackwardsCompatibilityVersion `json:"version"`
+	Version BackwardsCompatibilityVersion `json:"version"`
 }
 
 type BackwardsCompatibilityVersion string
@@ -336,7 +336,12 @@ func NewMicroserviceConfigmap(microservice Microservice, customersTenants []plat
 	}
 }
 
-// NewMicroserviceConfigmap create dolittle-config configmap specific for dolittle/runtime:8.0.0
+// NewMicroserviceConfigmap creates dolittle-config configmap specific for dolittle/runtime:8.0.0
+// where the backwardsCompatibility is set to V7. The backwardsCompatibility is set in the Runtime
+// with the DOLITTLE__RUNTIME__EVENTSTORE__BACKWARDSCOMPATIBILITY__VERSION env variable, but instead
+// of using an environment variable we can leverage ASP.NET appsettings.json file to set it.
+// We set it to V7 by default as the V6 option should only be used when upgrading the Runtime, while this deals
+// with only creating a new one. https://github.com/dolittle/Runtime/releases/tag/v8.0.0
 func NewMicroserviceConfigmapV8_0_0(microservice Microservice, customersTenants []platform.CustomerTenantInfo) *corev1.ConfigMap {
 	configmap := NewMicroserviceConfigmap(microservice, customersTenants)
 
@@ -355,11 +360,11 @@ func NewMicroserviceConfigmapV8_0_0(microservice Microservice, customersTenants 
 				},
 			},
 		},
-		dolittle: dolittle{
-			runtime: runtime{
-				eventStore: eventStore{
-					backwardsCompatibility: backwardsCompatibility{
-						version: V7BackwardsCompatibility,
+		Dolittle: dolittle{
+			Runtime: runtime{
+				EventStore: eventStore{
+					BackwardsCompatibility: backwardsCompatibility{
+						Version: V7BackwardsCompatibility,
 					},
 				},
 			},

--- a/pkg/dolittle/k8s/configmaps.go
+++ b/pkg/dolittle/k8s/configmaps.go
@@ -82,6 +82,8 @@ type AppsettingsLogging struct {
 	Console       AppsettingsConsole  `json:"Console"`
 }
 
+// AppsettingsV8_0_0 follows the structure of DOLITTLE__RUNTIME__EVENTSTORE__BACKWARDSCOMPATIBILITY__VERSION env variable
+// so that the ASP.NET configuration system will pick this setting in appsettings.json as that env variable
 type AppsettingsV8_0_0 struct {
 	Appsettings
 	Dolittle dolittle `json:"dolittle"`

--- a/pkg/dolittle/k8s/configmaps_test.go
+++ b/pkg/dolittle/k8s/configmaps_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -61,6 +62,25 @@ var _ = Describe("Configmaps", func() {
 
 			It("Confirm no management", func() {
 				Expect(strings.Contains(resource.Data["endpoints.json"], "management")).To(BeFalse())
+			})
+		})
+
+		Context("Creating NewMicroserviceConfigmap for 8.0.0", func() {
+			BeforeEach(func() {
+				resource = NewMicroserviceConfigmapV8_0_0(microservice, customerTenants)
+			})
+
+			It("should have it's appsettings.json follow the structure of DOLITTLE__RUNTIME__EVENTSTORE__BACKWARDSCOMPATIBILITY__VERSION", func() {
+				appsettingsString := resource.Data["appsettings.json"]
+				var appsettings AppsettingsV8_0_0
+				json.Unmarshal([]byte(appsettingsString), &appsettings)
+
+				// this shows that the unmarshaling worked in the correct structure
+				Expect(appsettings.Dolittle.Runtime.EventStore.BackwardsCompatibility.Version).To(Equal(V7BackwardsCompatibility))
+			})
+
+			It("should have backwardsCompatibility set to V7", func() {
+				Expect(strings.Contains(resource.Data["appsettings.json"], "V7")).To(BeTrue())
 			})
 		})
 

--- a/pkg/platform/microservice/simple/k8s/resources.go
+++ b/pkg/platform/microservice/simple/k8s/resources.go
@@ -37,6 +37,8 @@ func NewResources(
 	switch runtimeImage {
 	case "dolittle/runtime:6.1.0":
 		dolittleConfig = dolittleK8s.NewMicroserviceConfigmapV6_1_0(microservice, customerTenants)
+	case "dolittle/runtime:8.0.0":
+		dolittleConfig = 
 	case "none":
 		fallthrough
 	default:

--- a/pkg/platform/microservice/simple/k8s/resources.go
+++ b/pkg/platform/microservice/simple/k8s/resources.go
@@ -38,7 +38,7 @@ func NewResources(
 	case "dolittle/runtime:6.1.0":
 		dolittleConfig = dolittleK8s.NewMicroserviceConfigmapV6_1_0(microservice, customerTenants)
 	case "dolittle/runtime:8.0.0":
-		dolittleConfig = 
+		dolittleConfig = dolittleK8s.NewMicroserviceConfigmapV8_0_0(microservice, customerTenants)
 	case "none":
 		fallthrough
 	default:

--- a/pkg/platform/microservice/simple/k8s/resources_test.go
+++ b/pkg/platform/microservice/simple/k8s/resources_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"encoding/json"
 	"fmt"
 
 	dolittleK8s "github.com/dolittle/platform-api/pkg/dolittle/k8s"
@@ -130,6 +131,21 @@ var _ = Describe("Resources", func() {
 				resources := k8s.NewResources(isProduction, namespace, customer, application, customerTenants, input)
 				Expect(resources.IngressResources.NetworkPolicy).ToNot(BeNil())
 				Expect(resources.IngressResources.Ingresses).ToNot(BeNil())
+			})
+		})
+	})
+
+	Describe("Creating resources", func() {
+		Context("for v8.0.0 Runtime", func() {
+			It("should set backwardsCompatibility to V7 in appsettings.json", func() {
+				input.Extra.Runtimeimage = "dolittle/runtime:8.0.0"
+				resources := k8s.NewResources(isProduction, namespace, customer, application, customerTenants, input)
+
+				appsettingsString := resources.DolittleConfig.Data["appsettings.json"]
+				var appsettings dolittleK8s.AppsettingsV8_0_0
+				json.Unmarshal([]byte(appsettingsString), &appsettings)
+
+				Expect(appsettings.Dolittle.Runtime.EventStore.BackwardsCompatibility.Version).To(Equal(dolittleK8s.V7BackwardsCompatibility))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

When creating a new microservice that uses the [V8.0.0](https://github.com/dolittle/Runtime/releases/tag/v8.0.0) Runtime, we default to setting the `DOLITTLE__RUNTIME__EVENTSTORE__BACKWARDSCOMPATIBILITY__VERSION` env variable to `V7`. This is set through the `appsettings.json`, where the ASP.NET configuration system will pick it up just like it would be set in the env variable.
We default to `V7`, because to `V6` should only be used when upgrading a V6 Runtime to V8 and we don't currently support upgrading of the Runtime in the platform.

## Reference
- https://app.asana.com/0/1202023614957161/1202062723906543
- https://github.com/dolittle/Runtime/releases/tag/v8.0.0
- https://github.com/dolittle/Studio/pull/170
