### PR TITLE
Fix release workflow to only run when a pull request is merged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   setup:
+    if: github.event.pull_request.merged == true
     name: Setup
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Summary

Fix release workflow to only run when a pull request is merged (as per [GitHub example](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-when-a-pull-request-merges), as it used to also run when a pull request was merely closed with unmerged commits. For example PR https://github.com/dolittle/platform-api/pull/100 was closed, but the `release` workflow [still ran for it](https://github.com/dolittle/platform-api/runs/5549733761?check_suite_focus=true). In that case the `dolittle/establish-context-action@v2` action detected that no release should be made (due to [this line](https://github.com/dolittle/establish-context-action/blob/cb95abdb2cb21515db1b45478d6b9da20ca4853f/Source/MergedPullRequestContextEstablisher.ts#L54) and then eventually [this line](https://github.com/dolittle/establish-context-action/blob/cb95abdb2cb21515db1b45478d6b9da20ca4853f/Source/action.ts#L66)), but this workflow shouldn't have ran in the first place.