### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: dolittle/increment-version-action@v2
         with:
           version: ${{ steps.context.outputs.current-version }}
-          release-type: ${{ stept.context.outputs.release-type }}
+          release-type: ${{ steps.context.outputs.release-type }}
 
   test:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
         id: increment-version
         uses: dolittle/increment-version-action@v2
         with:
-          version: ${{ needs.setup.outputs.current-version }}
-          release-type: ${{ needs.setup.outputs.release-type }}
+          version: ${{ steps.context.outputs.current-version }}
+          release-type: ${{ stept.context.outputs.release-type }}
 
   test:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
## Summary

- When creating an application, it is possible to define customTenants per environment
- Creating applications uses ./modules/dolittle-application-with-resources.
- Fixes the workflow
- Retrigger release for https://github.com/dolittle/platform-api/pull/109