### PR TITLE
Enable head container commands and args to be defined on microservice creation

### DIFF
--- a/docs/microservice.md
+++ b/docs/microservice.md
@@ -18,7 +18,7 @@ curl -XPOST localhost:8081/microservice \
 -H 'x-shared-secret: FAKE' \
 -H 'Tenant-ID: 453e04a7-4f9d-42f2-b36c-d51fa2c83fa3' \
 -H 'User-ID: local-dev' \
--H "Content-Type: application/json" \
+-H 'Content-Type: application/json' \
 -d '
 {
   "dolittle": {
@@ -26,17 +26,21 @@ curl -XPOST localhost:8081/microservice \
     "customerId": "453e04a7-4f9d-42f2-b36c-d51fa2c83fa3",
     "microserviceId": "c96ab893-7df5-4065-a105-930c2c264ac2"
   },
-  "name": "Order1",
+  "name": "Test",
   "kind": "simple",
   "environment": "Dev",
   "extra": {
     "headImage": "nginxdemos/hello:latest",
-    "runtimeImage": "dolittle/runtime:7.6.0",
+    "runtimeImage": "dolittle/runtime:8.0.0",
     "ingress": {
       "path": "/",
       "pathType": "Prefix"
     },
-    "isPublic": true
+    "isPublic": true,
+    "headCommand": {
+      "commands": [""],
+      "args": [""]
+    }
   }
 }'
 ```

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -155,6 +155,13 @@ type HttpInputSimpleExtra struct {
 	Runtimeimage string                 `json:"runtimeImage"`
 	Ingress      HttpInputSimpleIngress `json:"ingress"`
 	Ispublic     bool                   `json:"isPublic"`
+	Headcommand  HttpInputSimpleCommand `json:"headCommand"`
+}
+
+// @joel check and think about this https://stackoverflow.com/a/66078726/5806412
+type HttpInputSimpleCommand struct {
+	Commands []string `json:"command"`
+	Args     []string `json:"args"`
 }
 
 type HttpInputBusinessMomentAdaptorInfo struct {

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -158,9 +158,8 @@ type HttpInputSimpleExtra struct {
 	Headcommand  HttpInputSimpleCommand `json:"headCommand"`
 }
 
-// @joel check and think about this https://stackoverflow.com/a/66078726/5806412
 type HttpInputSimpleCommand struct {
-	Commands []string `json:"command"`
+	Commands []string `json:"commands"`
 	Args     []string `json:"args"`
 }
 

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -159,8 +159,8 @@ type HttpInputSimpleExtra struct {
 }
 
 type HttpInputSimpleCommand struct {
-	Commands []string `json:"commands"`
-	Args     []string `json:"args"`
+	Command []string `json:"command"`
+	Args    []string `json:"args"`
 }
 
 type HttpInputBusinessMomentAdaptorInfo struct {

--- a/pkg/platform/microservice/simple/k8s/resources.go
+++ b/pkg/platform/microservice/simple/k8s/resources.go
@@ -87,6 +87,7 @@ func NewDeployment(microservice dolittleK8s.Microservice, extra platform.HttpInp
 
 	deployment := dolittleK8s.NewDeployment(microservice, headImage, runtimeImage)
 
+	// the head container should always be the first container
 	deployment.Spec.Template.Spec.Containers[0].Command = headCommand.Commands
 	deployment.Spec.Template.Spec.Containers[0].Args = headCommand.Args
 	deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = extra.HeadPort

--- a/pkg/platform/microservice/simple/k8s/resources.go
+++ b/pkg/platform/microservice/simple/k8s/resources.go
@@ -83,9 +83,12 @@ func NewResources(
 func NewDeployment(microservice dolittleK8s.Microservice, extra platform.HttpInputSimpleExtra) *appsv1.Deployment {
 	headImage := extra.Headimage
 	runtimeImage := extra.Runtimeimage
+	headCommand := extra.Headcommand
 
 	deployment := dolittleK8s.NewDeployment(microservice, headImage, runtimeImage)
 
+	deployment.Spec.Template.Spec.Containers[0].Command = headCommand.Commands
+	deployment.Spec.Template.Spec.Containers[0].Args = headCommand.Args
 	deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = extra.HeadPort
 	return deployment
 }

--- a/pkg/platform/microservice/simple/k8s/resources.go
+++ b/pkg/platform/microservice/simple/k8s/resources.go
@@ -88,11 +88,11 @@ func NewDeployment(microservice dolittleK8s.Microservice, extra platform.HttpInp
 	deployment := dolittleK8s.NewDeployment(microservice, headImage, runtimeImage)
 
 	// the head container should always be the first container so we can trust in that for now
-	deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = extra.HeadPort
-	// the Command property is equal to Dockers ENTRYPOINT, check https://stackoverflow.com/a/66078726/5806412
-	deployment.Spec.Template.Spec.Containers[0].Command = headCommand.Commands
-	// the Args property is equal to Dockers CMD
-	deployment.Spec.Template.Spec.Containers[0].Args = headCommand.Args
+	headContainer := deployment.Spec.Template.Spec.Containers[0]
+
+	headContainer.Ports[0].ContainerPort = extra.HeadPort
+	headContainer.Command = headCommand.Command
+	headContainer.Args = headCommand.Args
 	return deployment
 }
 

--- a/pkg/platform/microservice/simple/k8s/resources.go
+++ b/pkg/platform/microservice/simple/k8s/resources.go
@@ -87,10 +87,12 @@ func NewDeployment(microservice dolittleK8s.Microservice, extra platform.HttpInp
 
 	deployment := dolittleK8s.NewDeployment(microservice, headImage, runtimeImage)
 
-	// the head container should always be the first container
-	deployment.Spec.Template.Spec.Containers[0].Command = headCommand.Commands
-	deployment.Spec.Template.Spec.Containers[0].Args = headCommand.Args
+	// the head container should always be the first container so we can trust in that for now
 	deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort = extra.HeadPort
+	// the Command property is equal to Dockers ENTRYPOINT, check https://stackoverflow.com/a/66078726/5806412
+	deployment.Spec.Template.Spec.Containers[0].Command = headCommand.Commands
+	// the Args property is equal to Dockers CMD
+	deployment.Spec.Template.Spec.Containers[0].Args = headCommand.Args
 	return deployment
 }
 

--- a/pkg/platform/microservice/simple/k8s/resources.go
+++ b/pkg/platform/microservice/simple/k8s/resources.go
@@ -88,7 +88,7 @@ func NewDeployment(microservice dolittleK8s.Microservice, extra platform.HttpInp
 	deployment := dolittleK8s.NewDeployment(microservice, headImage, runtimeImage)
 
 	// the head container should always be the first container so we can trust in that for now
-	headContainer := deployment.Spec.Template.Spec.Containers[0]
+	headContainer := &deployment.Spec.Template.Spec.Containers[0]
 
 	headContainer.Ports[0].ContainerPort = extra.HeadPort
 	headContainer.Command = headCommand.Command

--- a/pkg/platform/microservice/simple/k8s/resources_test.go
+++ b/pkg/platform/microservice/simple/k8s/resources_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dolittle/platform-api/pkg/platform/microservice/simple/k8s"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("Resources", func() {
@@ -151,18 +150,14 @@ var _ = Describe("Resources", func() {
 		})
 
 		Context("with CLI arguments for the head container", func() {
-			When("the CLI arguments are empty", func() {
+			When("the CLI arguments are not set", func() {
 				It("should default to empty arguments", func() {
 					resources := k8s.NewResources(isProduction, namespace, customer, application, customerTenants, input)
 
-					var headContainer v1.Container
-					for _, container := range resources.Deployment.Spec.Template.Spec.Containers {
-						if container.Name == "head" {
-							headContainer = container
-						}
-					}
+					headContainer := resources.Deployment.Spec.Template.Spec.Containers[0]
 
-					Expect(headContainer.Command).To(BeNil())
+					Expect(headContainer).ToNot(BeNil())
+					Expect(headContainer.Command).To(BeEmpty())
 					Expect(headContainer.Args).To(BeEmpty())
 				})
 			})
@@ -177,13 +172,9 @@ var _ = Describe("Resources", func() {
 					input.Extra.Headcommand = headCommand
 					resources := k8s.NewResources(isProduction, namespace, customer, application, customerTenants, input)
 
-					var headContainer v1.Container
-					for _, container := range resources.Deployment.Spec.Template.Spec.Containers {
-						if container.Name == "head" {
-							headContainer = container
-						}
-					}
+					headContainer := resources.Deployment.Spec.Template.Spec.Containers[0]
 
+					Expect(headContainer).ToNot(BeNil())
 					Expect(headContainer.Command).To(Equal(headCommand.Commands))
 					Expect(headContainer.Args).To(Equal(headCommand.Args))
 				})

--- a/pkg/platform/microservice/simple/k8s/resources_test.go
+++ b/pkg/platform/microservice/simple/k8s/resources_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dolittle/platform-api/pkg/platform/microservice/simple/k8s"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("Resources", func() {
@@ -135,7 +136,7 @@ var _ = Describe("Resources", func() {
 		})
 	})
 
-	Describe("Creating resources", func() {
+	Describe("Creating new resources", func() {
 		Context("for v8.0.0 Runtime", func() {
 			It("should set backwardsCompatibility to V7 in appsettings.json", func() {
 				input.Extra.Runtimeimage = "dolittle/runtime:8.0.0"
@@ -146,6 +147,46 @@ var _ = Describe("Resources", func() {
 				json.Unmarshal([]byte(appsettingsString), &appsettings)
 
 				Expect(appsettings.Dolittle.Runtime.EventStore.BackwardsCompatibility.Version).To(Equal(dolittleK8s.V7BackwardsCompatibility))
+			})
+		})
+
+		Context("with CLI arguments for the head container", func() {
+			When("the CLI arguments are empty", func() {
+				It("should default to empty arguments", func() {
+					resources := k8s.NewResources(isProduction, namespace, customer, application, customerTenants, input)
+
+					var headContainer v1.Container
+					for _, container := range resources.Deployment.Spec.Template.Spec.Containers {
+						if container.Name == "head" {
+							headContainer = container
+						}
+					}
+
+					Expect(headContainer.Command).To(BeNil())
+					Expect(headContainer.Args).To(BeEmpty())
+				})
+			})
+
+			When("the CLI arguments are set", func() {
+				It("should set them", func() {
+					headCommand := platform.HttpInputSimpleCommand{
+						Commands: []string{"/bin/sh", "-c"},
+						Args:     []string{"echo", "-n", "im a test string"},
+					}
+
+					input.Extra.Headcommand = headCommand
+					resources := k8s.NewResources(isProduction, namespace, customer, application, customerTenants, input)
+
+					var headContainer v1.Container
+					for _, container := range resources.Deployment.Spec.Template.Spec.Containers {
+						if container.Name == "head" {
+							headContainer = container
+						}
+					}
+
+					Expect(headContainer.Command).To(Equal(headCommand.Commands))
+					Expect(headContainer.Args).To(Equal(headCommand.Args))
+				})
 			})
 		})
 	})

--- a/pkg/platform/microservice/simple/k8s/resources_test.go
+++ b/pkg/platform/microservice/simple/k8s/resources_test.go
@@ -165,8 +165,8 @@ var _ = Describe("Resources", func() {
 			When("the CLI arguments are set", func() {
 				It("should set them", func() {
 					headCommand := platform.HttpInputSimpleCommand{
-						Commands: []string{"/bin/sh", "-c"},
-						Args:     []string{"echo", "-n", "im a test string"},
+						Command: []string{"/bin/sh", "-c"},
+						Args:    []string{"echo", "-n", "im a test string"},
 					}
 
 					input.Extra.Headcommand = headCommand
@@ -175,7 +175,7 @@ var _ = Describe("Resources", func() {
 					headContainer := resources.Deployment.Spec.Template.Spec.Containers[0]
 
 					Expect(headContainer).ToNot(BeNil())
-					Expect(headContainer.Command).To(Equal(headCommand.Commands))
+					Expect(headContainer.Command).To(Equal(headCommand.Command))
 					Expect(headContainer.Args).To(Equal(headCommand.Args))
 				})
 			})


### PR DESCRIPTION
## Summary

Adds a new `HttpInputSimpleCommand` struct to the `Extra` field on the request for microservice creation. If the fields aren't specified the `command` and `args` fields will be emitted from the created deployment as the properties have the `omitempty` tag.

## Reference
- https://github.com/dolittle-platform/Operations/pull/209
- https://app.asana.com/0/1202121266838773/1202159723413336