### PR TITLE
Studio include kafka

### DIFF
--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -21,7 +21,7 @@ import (
 	"github.com/dolittle/platform-api/pkg/platform/job"
 	jobK8s "github.com/dolittle/platform-api/pkg/platform/job/k8s"
 	platformK8s "github.com/dolittle/platform-api/pkg/platform/k8s"
-	"github.com/dolittle/platform-api/pkg/platform/listeners"
+	m3ConnectorListeners "github.com/dolittle/platform-api/pkg/platform/listeners/m3connector"
 	"github.com/dolittle/platform-api/pkg/platform/microservice"
 	"github.com/dolittle/platform-api/pkg/platform/microservice/environmentVariables"
 	"github.com/dolittle/platform-api/pkg/platform/microservice/purchaseorderapi"
@@ -122,7 +122,7 @@ var serverCMD = &cobra.Command{
 		go job.NewCustomerJobListener(k8sClient, gitRepo, logContext.WithField("context", "listener-job-customer"))
 		go job.NewApplicationJobListener(k8sClient, gitRepo, logContext.WithField("context", "listener-job-application"))
 
-		go listeners.NewM3ConnectorConfigmapListener(k8sClient, gitRepo, gitRepo, logContext.WithField("context", "listener-m3connector-kafka-files"))
+		go m3ConnectorListeners.NewKafkaFilesConfigmapListener(k8sClient, gitRepo, gitRepo, logContext.WithField("context", "listener-m3connector-kafka-files"))
 
 		microserviceService := microservice.NewService(
 			isProduction,

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dolittle/platform-api/pkg/platform/job"
 	jobK8s "github.com/dolittle/platform-api/pkg/platform/job/k8s"
 	platformK8s "github.com/dolittle/platform-api/pkg/platform/k8s"
+	"github.com/dolittle/platform-api/pkg/platform/listeners"
 	"github.com/dolittle/platform-api/pkg/platform/microservice"
 	"github.com/dolittle/platform-api/pkg/platform/microservice/environmentVariables"
 	"github.com/dolittle/platform-api/pkg/platform/microservice/purchaseorderapi"
@@ -120,6 +121,8 @@ var serverCMD = &cobra.Command{
 		// today via the resources, it is not clear which is which "platform-environment".
 		go job.NewCustomerJobListener(k8sClient, gitRepo, logContext.WithField("context", "listener-job-customer"))
 		go job.NewApplicationJobListener(k8sClient, gitRepo, logContext.WithField("context", "listener-job-application"))
+
+		go listeners.NewM3ConnectorConfigmapListener(k8sClient, gitRepo, gitRepo, logContext.WithField("context", "listener-m3connector-kafka-files"))
 
 		microserviceService := microservice.NewService(
 			isProduction,

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -122,7 +122,7 @@ var serverCMD = &cobra.Command{
 		go job.NewCustomerJobListener(k8sClient, gitRepo, logContext.WithField("context", "listener-job-customer"))
 		go job.NewApplicationJobListener(k8sClient, gitRepo, logContext.WithField("context", "listener-job-application"))
 
-		go m3ConnectorListeners.NewKafkaFilesConfigmapListener(k8sClient, gitRepo, gitRepo, logContext.WithField("context", "listener-m3connector-kafka-files"))
+		go m3ConnectorListeners.NewKafkaFilesConfigmapListener(k8sClient, gitRepo, logContext.WithField("context", "listener-m3connector-kafka-files"))
 
 		microserviceService := microservice.NewService(
 			isProduction,

--- a/pkg/platform/application/doc.go
+++ b/pkg/platform/application/doc.go
@@ -34,7 +34,8 @@ type HttpInputApplicationEnvironment struct {
 }
 
 type ApplicationConnections struct {
-	Kafka bool `json:"kafka"`
+	Kafka       bool `json:"kafka"`
+	M3Connector bool `json:"m3Connector"`
 }
 
 type HttpResponseApplication struct {
@@ -44,12 +45,12 @@ type HttpResponseApplication struct {
 	CustomerName  string                          `json:"customerName"`
 	Environments  []HttpResponseEnvironment       `json:"environments"`
 	Microservices []platform.HttpMicroserviceBase `json:"microservices,omitempty"`
-	Connections   ApplicationConnections          `json:"connections"`
 }
 
 type HttpResponseEnvironment struct {
-	AutomationEnabled bool   `json:"automationEnabled"`
-	Name              string `json:"name"`
+	AutomationEnabled bool                   `json:"automationEnabled"`
+	Name              string                 `json:"name"`
+	Connections       ApplicationConnections `json:"connections"`
 }
 
 type HttpResponseApplications struct {

--- a/pkg/platform/application/doc.go
+++ b/pkg/platform/application/doc.go
@@ -33,11 +33,6 @@ type HttpInputApplicationEnvironment struct {
 	CustomerTenant []HttpInputApplicationEnvironmentCustomerTenant `json:"customerTenants"`
 }
 
-type EnvironmentConnections struct {
-	Kafka       bool `json:"kafka"`
-	M3Connector bool `json:"m3Connector"`
-}
-
 type HttpResponseApplication struct {
 	ID            string                          `json:"id"`
 	Name          string                          `json:"name"`
@@ -48,9 +43,9 @@ type HttpResponseApplication struct {
 }
 
 type HttpResponseEnvironment struct {
-	AutomationEnabled bool                   `json:"automationEnabled"`
-	Name              string                 `json:"name"`
-	Connections       EnvironmentConnections `json:"connections"`
+	AutomationEnabled bool                                `json:"automationEnabled"`
+	Name              string                              `json:"name"`
+	Connections       platform.HttpEnvironmentConnections `json:"connections"`
 }
 
 type HttpResponseApplications struct {

--- a/pkg/platform/application/doc.go
+++ b/pkg/platform/application/doc.go
@@ -33,7 +33,7 @@ type HttpInputApplicationEnvironment struct {
 	CustomerTenant []HttpInputApplicationEnvironmentCustomerTenant `json:"customerTenants"`
 }
 
-type ApplicationConnections struct {
+type EnvironmentConnections struct {
 	Kafka       bool `json:"kafka"`
 	M3Connector bool `json:"m3Connector"`
 }
@@ -50,7 +50,7 @@ type HttpResponseApplication struct {
 type HttpResponseEnvironment struct {
 	AutomationEnabled bool                   `json:"automationEnabled"`
 	Name              string                 `json:"name"`
-	Connections       ApplicationConnections `json:"connections"`
+	Connections       EnvironmentConnections `json:"connections"`
 }
 
 type HttpResponseApplications struct {

--- a/pkg/platform/application/doc.go
+++ b/pkg/platform/application/doc.go
@@ -33,6 +33,10 @@ type HttpInputApplicationEnvironment struct {
 	CustomerTenant []HttpInputApplicationEnvironmentCustomerTenant `json:"customerTenants"`
 }
 
+type ApplicationConnections struct {
+	Kafka bool `json:"kafka"`
+}
+
 type HttpResponseApplication struct {
 	ID            string                          `json:"id"`
 	Name          string                          `json:"name"`
@@ -40,6 +44,7 @@ type HttpResponseApplication struct {
 	CustomerName  string                          `json:"customerName"`
 	Environments  []HttpResponseEnvironment       `json:"environments"`
 	Microservices []platform.HttpMicroserviceBase `json:"microservices,omitempty"`
+	Connections   ApplicationConnections          `json:"connections"`
 }
 
 type HttpResponseEnvironment struct {

--- a/pkg/platform/application/service.go
+++ b/pkg/platform/application/service.go
@@ -316,10 +316,10 @@ func (s *Service) GetByID(w http.ResponseWriter, r *http.Request) {
 			return HttpResponseEnvironment{
 				AutomationEnabled: s.gitRepo.IsAutomationEnabledWithStudioConfig(studioInfo.StudioConfig, applicationID, environment.Name),
 				Name:              environment.Name,
+				Connections:       ApplicationConnections(environment.Connections),
 			}
 		}).([]HttpResponseEnvironment),
 		Microservices: microservices,
-		Connections:   ApplicationConnections(application.Connections),
 	}
 	utils.RespondWithJSON(w, http.StatusOK, response)
 }

--- a/pkg/platform/application/service.go
+++ b/pkg/platform/application/service.go
@@ -319,6 +319,7 @@ func (s *Service) GetByID(w http.ResponseWriter, r *http.Request) {
 			}
 		}).([]HttpResponseEnvironment),
 		Microservices: microservices,
+		Connections:   ApplicationConnections(application.Connections),
 	}
 	utils.RespondWithJSON(w, http.StatusOK, response)
 }

--- a/pkg/platform/application/service.go
+++ b/pkg/platform/application/service.go
@@ -316,7 +316,7 @@ func (s *Service) GetByID(w http.ResponseWriter, r *http.Request) {
 			return HttpResponseEnvironment{
 				AutomationEnabled: s.gitRepo.IsAutomationEnabledWithStudioConfig(studioInfo.StudioConfig, applicationID, environment.Name),
 				Name:              environment.Name,
-				Connections:       EnvironmentConnections(environment.Connections),
+				Connections:       platform.HttpEnvironmentConnections(environment.Connections),
 			}
 		}).([]HttpResponseEnvironment),
 		Microservices: microservices,

--- a/pkg/platform/application/service.go
+++ b/pkg/platform/application/service.go
@@ -316,7 +316,7 @@ func (s *Service) GetByID(w http.ResponseWriter, r *http.Request) {
 			return HttpResponseEnvironment{
 				AutomationEnabled: s.gitRepo.IsAutomationEnabledWithStudioConfig(studioInfo.StudioConfig, applicationID, environment.Name),
 				Name:              environment.Name,
-				Connections:       ApplicationConnections(environment.Connections),
+				Connections:       EnvironmentConnections(environment.Connections),
 			}
 		}).([]HttpResponseEnvironment),
 		Microservices: microservices,

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -150,17 +150,23 @@ type HttpInputSimpleInfo struct {
 }
 
 type HttpInputSimpleExtra struct {
-	Headimage    string                 `json:"headImage"`
-	HeadPort     int32                  `json:"headPort"`
-	Runtimeimage string                 `json:"runtimeImage"`
-	Ingress      HttpInputSimpleIngress `json:"ingress"`
-	Ispublic     bool                   `json:"isPublic"`
-	Headcommand  HttpInputSimpleCommand `json:"headCommand"`
+	Headimage    string                     `json:"headImage"`
+	HeadPort     int32                      `json:"headPort"`
+	Runtimeimage string                     `json:"runtimeImage"`
+	Ingress      HttpInputSimpleIngress     `json:"ingress"`
+	Ispublic     bool                       `json:"isPublic"`
+	Headcommand  HttpInputSimpleCommand     `json:"headCommand"`
+	Connections  HttpEnvironmentConnections `json:"connections"`
 }
 
 type HttpInputSimpleCommand struct {
 	Command []string `json:"command"`
 	Args    []string `json:"args"`
+}
+
+type HttpEnvironmentConnections struct {
+	Kafka       bool `json:"kafka"`
+	M3Connector bool `json:"m3Connector"`
 }
 
 type HttpInputBusinessMomentAdaptorInfo struct {

--- a/pkg/platform/doc.go
+++ b/pkg/platform/doc.go
@@ -165,7 +165,6 @@ type HttpInputSimpleCommand struct {
 }
 
 type HttpEnvironmentConnections struct {
-	Kafka       bool `json:"kafka"`
 	M3Connector bool `json:"m3Connector"`
 }
 

--- a/pkg/platform/listeners/doc.go
+++ b/pkg/platform/listeners/doc.go
@@ -1,0 +1,1 @@
+package listeners

--- a/pkg/platform/listeners/m3connector.go
+++ b/pkg/platform/listeners/m3connector.go
@@ -1,0 +1,201 @@
+package listeners
+
+// Inspired by https://github.com/feiskyer/kubernetes-handbook/blob/master/examples/client/informer/informer.go
+// Inspired by https://github.com/heptiolabs/eventrouter/blob/master/main.go
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dolittle/platform-api/pkg/platform/storage"
+	gitStorage "github.com/dolittle/platform-api/pkg/platform/storage/git"
+	"github.com/sirupsen/logrus"
+	"github.com/thoas/go-funk"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type m3ConnectorController struct {
+	informerFactory   informers.SharedInformerFactory
+	configMapInformer coreinformers.ConfigMapInformer
+	logContext        logrus.FieldLogger
+	gitSync           gitStorage.GitSync
+	repo              storage.RepoApplication
+}
+
+func (c *m3ConnectorController) Run(stopCh chan struct{}) error {
+	c.informerFactory.Start(stopCh)
+	// wait for the initial synchronization of the local cache.
+	if !cache.WaitForCacheSync(stopCh, c.configMapInformer.Informer().HasSynced) {
+		return fmt.Errorf("failed to sync")
+	}
+	return nil
+}
+
+func (c *m3ConnectorController) getEnvironment(resource *corev1.ConfigMap) (storage.JSONEnvironment, error) {
+	customerID := resource.Annotations["dolittle.io/tenant-id"]
+	applicationID := resource.Annotations["dolittle.io/application-id"]
+
+	application, err := c.repo.GetApplication(customerID, applicationID)
+	if err != nil {
+		// This can be noisy due to the plaftform environment :(
+		if !errors.Is(err, storage.ErrNotFound) {
+			c.logContext.WithField("error", err).Error("error loading GetApplication")
+		}
+		return storage.JSONEnvironment{}, storage.ErrNotFound
+	}
+
+	// Find environment
+	found := funk.Find(application.Environments, func(environment storage.JSONEnvironment) bool {
+		return environment.Name == resource.Labels["environment"]
+	})
+
+	if found == nil {
+		c.logContext.WithField("environment", resource.Labels["environment"]).Error("environment not found")
+		return storage.JSONEnvironment{}, storage.ErrNotFound
+	}
+
+	return found.(storage.JSONEnvironment), nil
+}
+
+func (c *m3ConnectorController) saveEnvironment(resource *corev1.ConfigMap, environment storage.JSONEnvironment) error {
+	customerID := resource.Annotations["dolittle.io/tenant-id"]
+	applicationID := resource.Annotations["dolittle.io/application-id"]
+
+	application, err := c.repo.GetApplication(customerID, applicationID)
+	if err != nil {
+		return err
+	}
+
+	for index, currentEnvironment := range application.Environments {
+		if currentEnvironment.Name != environment.Name {
+			continue
+		}
+		application.Environments[index] = environment
+	}
+
+	return c.repo.SaveApplication(application)
+}
+
+func (c *m3ConnectorController) upsert(resource *corev1.ConfigMap) {
+	environment, err := c.getEnvironment(resource)
+	if err != nil {
+		// This can be noisy due to the plaftform environment :(
+		if !errors.Is(err, storage.ErrNotFound) {
+			c.logContext.WithField("error", err).Error("error loading GetApplication")
+		}
+		return
+	}
+
+	if environment.Connections.M3Connector {
+		return
+	}
+
+	environment.Connections.Kafka = true
+	environment.Connections.M3Connector = true
+
+	err = c.saveEnvironment(resource, environment)
+	if err != nil {
+		c.logContext.WithField("error", err).Error("failed to save environment")
+	}
+
+	c.logContext.Info("application is m3connector aware")
+}
+
+func (c *m3ConnectorController) add(obj interface{}) {
+	resource := obj.(*corev1.ConfigMap)
+	c.upsert(resource)
+}
+
+func (c *m3ConnectorController) update(old, new interface{}) {
+	resource := new.(*corev1.ConfigMap)
+	c.upsert(resource)
+}
+
+func (c *m3ConnectorController) delete(obj interface{}) {
+	resource := obj.(*corev1.ConfigMap)
+	c.logContext.Infof("DELETED: %s %s/%s", resource.APIVersion, resource.Namespace, resource.Name)
+
+	environment, err := c.getEnvironment(resource)
+	if err != nil {
+		// This can be noisy due to the plaftform environment :(
+		if !errors.Is(err, storage.ErrNotFound) {
+			c.logContext.WithField("error", err).Error("error loading GetApplication")
+		}
+		return
+	}
+
+	environment.Connections.Kafka = false
+	environment.Connections.M3Connector = false
+	err = c.saveEnvironment(resource, environment)
+	if err != nil {
+		c.logContext.WithField("error", err).Error("failed to save environment")
+	}
+
+	c.logContext.Info("application updated, m3connector no longer enabled for this environment")
+
+}
+
+func NewM3ConnectorConfigmapListenerController(
+	informerFactory informers.SharedInformerFactory,
+	gitSync gitStorage.GitSync,
+	repo storage.RepoApplication,
+	logContext logrus.FieldLogger,
+) *m3ConnectorController {
+	configMapInformer := informerFactory.Core().V1().ConfigMaps()
+
+	c := &m3ConnectorController{
+		informerFactory:   informerFactory,
+		configMapInformer: configMapInformer,
+		logContext:        logContext,
+		gitSync:           gitSync,
+		repo:              repo,
+	}
+
+	// FilteringResourceEventHandler
+	handler := cache.FilteringResourceEventHandler{
+		FilterFunc: func(obj interface{}) bool {
+			resource := obj.(*corev1.ConfigMap)
+
+			if !strings.HasPrefix(resource.Namespace, "application-") {
+				return false
+			}
+
+			if !strings.HasSuffix(resource.Name, "-kafka-files") {
+				return false
+			}
+
+			return true
+		},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    c.add,
+			UpdateFunc: c.update,
+			DeleteFunc: c.delete,
+		},
+	}
+	configMapInformer.Informer().AddEventHandler(handler)
+	return c
+}
+
+func NewM3ConnectorConfigmapListener(
+	client kubernetes.Interface,
+	gitSync gitStorage.GitSync,
+	repo storage.RepoApplication,
+	logContext logrus.FieldLogger,
+) {
+	// TODO do I need a name space?
+	factory := informers.NewSharedInformerFactoryWithOptions(client, time.Hour*24)
+	controller := NewM3ConnectorConfigmapListenerController(factory, gitSync, repo, logContext)
+	stop := make(chan struct{})
+	defer close(stop)
+	err := controller.Run(stop)
+	if err != nil {
+		logContext.Fatal(err)
+	}
+	select {}
+}

--- a/pkg/platform/listeners/m3connector.go
+++ b/pkg/platform/listeners/m3connector.go
@@ -79,6 +79,8 @@ func (c *m3ConnectorController) saveEnvironment(resource *corev1.ConfigMap, envi
 }
 
 func (c *m3ConnectorController) upsert(resource *corev1.ConfigMap) {
+	// TODO this should be revisited when we look at rebuilding an empty cluster
+	// Having the source of truth, mixed with listening for changes will need more logic
 	environment, err := c.getEnvironment(resource)
 	if err != nil {
 		// This can be noisy due to the plaftform environment :(

--- a/pkg/platform/listeners/m3connector.go
+++ b/pkg/platform/listeners/m3connector.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dolittle/platform-api/pkg/platform/storage"
 	gitStorage "github.com/dolittle/platform-api/pkg/platform/storage/git"
 	"github.com/sirupsen/logrus"
-	"github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -50,17 +49,14 @@ func (c *m3ConnectorController) getEnvironment(resource *corev1.ConfigMap) (stor
 		return storage.JSONEnvironment{}, storage.ErrNotFound
 	}
 
-	// Find environment
-	found := funk.Find(application.Environments, func(environment storage.JSONEnvironment) bool {
-		return environment.Name == resource.Labels["environment"]
-	})
+	environment, err := storage.GetEnvironment(application.Environments, resource.Labels["environment"])
 
-	if found == nil {
+	if err != nil {
 		c.logContext.WithField("environment", resource.Labels["environment"]).Error("environment not found")
 		return storage.JSONEnvironment{}, storage.ErrNotFound
 	}
 
-	return found.(storage.JSONEnvironment), nil
+	return environment, nil
 }
 
 func (c *m3ConnectorController) saveEnvironment(resource *corev1.ConfigMap, environment storage.JSONEnvironment) error {

--- a/pkg/platform/listeners/m3connector/kafkafiles.go
+++ b/pkg/platform/listeners/m3connector/kafkafiles.go
@@ -95,6 +95,7 @@ func (c *kafkaFilesController) upsert(resource *corev1.ConfigMap) {
 	err = c.saveEnvironment(resource, environment)
 	if err != nil {
 		c.logContext.WithField("error", err).Error("failed to save environment")
+		return
 	}
 
 	c.logContext.Info("application is m3connector aware")
@@ -126,10 +127,10 @@ func (c *kafkaFilesController) delete(obj interface{}) {
 	err = c.saveEnvironment(resource, environment)
 	if err != nil {
 		c.logContext.WithField("error", err).Error("failed to save environment")
+		return
 	}
 
 	c.logContext.Info("application updated, m3connector no longer enabled for this environment")
-
 }
 
 func NewKafkaFilesConfigmapListenerController(

--- a/pkg/platform/listeners/m3connector/kafkafiles.go
+++ b/pkg/platform/listeners/m3connector/kafkafiles.go
@@ -79,7 +79,8 @@ func (c *kafkaFilesController) upsert(resource *corev1.ConfigMap) {
 	// Having the source of truth, mixed with listening for changes will need more logic
 	environment, err := c.getEnvironment(resource)
 	if err != nil {
-		// This can be noisy due to the platform environment :(
+		// This can be noisy due to the platform environment :(, if we were to move
+		// to dev cluster for dev, this becomes less noisy :)
 		if !errors.Is(err, storage.ErrNotFound) {
 			c.logContext.WithField("error", err).Error("error getting environment info")
 		}
@@ -116,7 +117,8 @@ func (c *kafkaFilesController) delete(obj interface{}) {
 
 	environment, err := c.getEnvironment(resource)
 	if err != nil {
-		// This can be noisy due to the platform environment :(
+		// This can be noisy due to the platform environment :(, if we were to move
+		// to dev cluster for dev, this becomes less noisy :)
 		if !errors.Is(err, storage.ErrNotFound) {
 			c.logContext.WithField("error", err).Error("error getting environment info")
 		}

--- a/pkg/platform/microservice/handle_simple.go
+++ b/pkg/platform/microservice/handle_simple.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/dolittle/platform-api/pkg/platform"
+	"github.com/dolittle/platform-api/pkg/platform/storage"
 	"github.com/dolittle/platform-api/pkg/utils"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -14,6 +15,7 @@ func (s *service) handleSimpleMicroservice(
 	r *http.Request,
 	inputBytes []byte,
 	applicationInfo platform.Application,
+	environmentInfo storage.JSONEnvironment,
 	customerTenants []platform.CustomerTenantInfo,
 ) {
 	// Function assumes access check has taken place
@@ -40,6 +42,11 @@ func (s *service) handleSimpleMicroservice(
 	if validation.IsValidPortNum(int(ms.Extra.HeadPort)) != nil {
 		utils.RespondWithError(w, http.StatusBadRequest, "ms.Extra.HeadPort not a valid port number")
 		return
+	}
+
+	// Force to false
+	if !environmentInfo.Connections.M3Connector {
+		ms.Extra.Connections.M3Connector = false
 	}
 
 	err := s.simpleRepo.Create(msK8sInfo.Namespace, msK8sInfo.Customer, msK8sInfo.Application, customerTenants, ms)

--- a/pkg/platform/microservice/handle_simple.go
+++ b/pkg/platform/microservice/handle_simple.go
@@ -44,9 +44,9 @@ func (s *service) handleSimpleMicroservice(
 		return
 	}
 
-	// Force to false
 	if !environmentInfo.Connections.M3Connector {
-		ms.Extra.Connections.M3Connector = false
+		utils.RespondWithError(w, http.StatusBadRequest, "m3connector connection is not enabled")
+		return
 	}
 
 	err := s.simpleRepo.Create(msK8sInfo.Namespace, msK8sInfo.Customer, msK8sInfo.Application, customerTenants, ms)

--- a/pkg/platform/microservice/service.go
+++ b/pkg/platform/microservice/service.go
@@ -146,7 +146,9 @@ func (s *service) Create(w http.ResponseWriter, request *http.Request) {
 	// TODO check path
 	switch microserviceBase.Kind {
 	case platform.MicroserviceKindSimple:
-		s.handleSimpleMicroservice(w, request, requestBytes, applicationInfo, customerTenants)
+		// TODO need to pass in storageEnvironment :(
+		environmentInfo, _ := storage.GetEnvironment(storedApplication.Environments, environment)
+		s.handleSimpleMicroservice(w, request, requestBytes, applicationInfo, environmentInfo, customerTenants)
 	// TODO let us get simple to work and we can come back to these others.
 	//case platform.MicroserviceKindBusinessMomentsAdaptor:
 	//	s.handleBusinessMomentsAdaptor(w, request, requestBytes, applicationInfo, customerTenants)

--- a/pkg/platform/microservice/service.go
+++ b/pkg/platform/microservice/service.go
@@ -146,7 +146,6 @@ func (s *service) Create(w http.ResponseWriter, request *http.Request) {
 	// TODO check path
 	switch microserviceBase.Kind {
 	case platform.MicroserviceKindSimple:
-		// TODO need to pass in storageEnvironment :(
 		environmentInfo, _ := storage.GetEnvironment(storedApplication.Environments, environment)
 		s.handleSimpleMicroservice(w, request, requestBytes, applicationInfo, environmentInfo, customerTenants)
 	// TODO let us get simple to work and we can come back to these others.

--- a/pkg/platform/storage/doc.go
+++ b/pkg/platform/storage/doc.go
@@ -79,10 +79,7 @@ type JSONApplication struct {
 	Environments []JSONEnvironment `json:"environments"`
 	Status       JSONBuildStatus   `json:"status"`
 }
-
-// TODO I wonder where best to store this
 type JSONEnvironmentConnections struct {
-	Kafka       bool `json:"kafka"`
 	M3Connector bool `json:"m3Connector"`
 }
 

--- a/pkg/platform/storage/doc.go
+++ b/pkg/platform/storage/doc.go
@@ -81,15 +81,16 @@ type JSONApplication struct {
 }
 
 // TODO I wonder where best to store this
-type JSONApplicationConnections struct {
-	Kafka bool `json:"kafka"`
+type JSONEnvironmentConnections struct {
+	Kafka       bool `json:"kafka"`
+	M3Connector bool `json:"m3Connector"`
 }
 
 type JSONEnvironment struct {
 	Name                  string                        `json:"name"`
 	CustomerTenants       []platform.CustomerTenantInfo `json:"customerTenants"`
 	WelcomeMicroserviceID string                        `json:"welcomeMicroserviceID"`
-	Connections           JSONApplicationConnections    `json:"connections"`
+	Connections           JSONEnvironmentConnections    `json:"connections"`
 }
 
 type JSONCustomer struct {

--- a/pkg/platform/storage/doc.go
+++ b/pkg/platform/storage/doc.go
@@ -76,9 +76,8 @@ type JSONApplication struct {
 	CustomerID   string `json:"customerId"`
 	CustomerName string `json:"customerName"`
 
-	Environments []JSONEnvironment          `json:"environments"`
-	Status       JSONBuildStatus            `json:"status"`
-	Connections  JSONApplicationConnections `json:"connections"`
+	Environments []JSONEnvironment `json:"environments"`
+	Status       JSONBuildStatus   `json:"status"`
 }
 
 // TODO I wonder where best to store this
@@ -90,6 +89,7 @@ type JSONEnvironment struct {
 	Name                  string                        `json:"name"`
 	CustomerTenants       []platform.CustomerTenantInfo `json:"customerTenants"`
 	WelcomeMicroserviceID string                        `json:"welcomeMicroserviceID"`
+	Connections           JSONApplicationConnections    `json:"connections"`
 }
 
 type JSONCustomer struct {

--- a/pkg/platform/storage/doc.go
+++ b/pkg/platform/storage/doc.go
@@ -76,8 +76,14 @@ type JSONApplication struct {
 	CustomerID   string `json:"customerId"`
 	CustomerName string `json:"customerName"`
 
-	Environments []JSONEnvironment `json:"environments"`
-	Status       JSONBuildStatus   `json:"status"`
+	Environments []JSONEnvironment          `json:"environments"`
+	Status       JSONBuildStatus            `json:"status"`
+	Connections  JSONApplicationConnections `json:"connections"`
+}
+
+// TODO I wonder where best to store this
+type JSONApplicationConnections struct {
+	Kafka bool `json:"kafka"`
 }
 
 type JSONEnvironment struct {

--- a/pkg/platform/storage/environment.go
+++ b/pkg/platform/storage/environment.go
@@ -9,3 +9,15 @@ func EnvironmentExists(environments []JSONEnvironment, environment string) bool 
 		return item.Name == environment
 	})
 }
+
+func GetEnvironment(environments []JSONEnvironment, environment string) (JSONEnvironment, error) {
+	// Find environment
+	found := funk.Find(environments, func(item JSONEnvironment) bool {
+		return item.Name == environment
+	})
+
+	if found == nil {
+		return JSONEnvironment{}, ErrNotFound
+	}
+	return found.(JSONEnvironment), nil
+}

--- a/pkg/platform/storage/environment.go
+++ b/pkg/platform/storage/environment.go
@@ -11,7 +11,6 @@ func EnvironmentExists(environments []JSONEnvironment, environment string) bool 
 }
 
 func GetEnvironment(environments []JSONEnvironment, environment string) (JSONEnvironment, error) {
-	// Find environment
 	found := funk.Find(environments, func(item JSONEnvironment) bool {
 		return item.Name == environment
 	})


### PR DESCRIPTION
## Summary

- Listen for changes on where we will write connection details for m3connector and update the application
- Within application a new connection object exists in environment, this is used by the frontend today to provide a simple user experience
- When creating a microservice we will now add the m3connector volumes to the deployment