### PR TITLE
Only check if the m3 connector environment variable is set when selecting to use the M3 connector

### DIFF
--- a/pkg/platform/microservice/handle_simple.go
+++ b/pkg/platform/microservice/handle_simple.go
@@ -44,9 +44,11 @@ func (s *service) handleSimpleMicroservice(
 		return
 	}
 
-	if !environmentInfo.Connections.M3Connector {
-		utils.RespondWithError(w, http.StatusBadRequest, "m3connector connection is not enabled")
-		return
+	if ms.Extra.Connections.M3Connector {
+		if !environmentInfo.Connections.M3Connector {
+			utils.RespondWithError(w, http.StatusBadRequest, "m3connector connection is not enabled")
+			return
+		}
 	}
 
 	err := s.simpleRepo.Create(msK8sInfo.Namespace, msK8sInfo.Customer, msK8sInfo.Application, customerTenants, ms)


### PR DESCRIPTION
## Summary

Fix error when trying to create a base microservice without the M3Connector and the environment variable set.
