### PR TITLE
Add handling for both `data` & `binaryData` properties in configmaps

### DIFF
--- a/pkg/platform/microservice/configFiles/configFiles_suite_test.go
+++ b/pkg/platform/microservice/configFiles/configFiles_suite_test.go
@@ -1,0 +1,13 @@
+package configFiles_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfigFiles(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ConfigFiles Suite")
+}

--- a/pkg/platform/microservice/configFiles/repo.go
+++ b/pkg/platform/microservice/configFiles/repo.go
@@ -3,6 +3,8 @@ package configFiles
 import (
 	"errors"
 
+	"unicode/utf8"
+
 	platformK8s "github.com/dolittle/platform-api/pkg/platform/k8s"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
@@ -20,8 +22,8 @@ type k8sRepo struct {
 	logContext      logrus.FieldLogger
 }
 type MicroserviceConfigFile struct {
-	Name       string `json:"name"`
-	BinaryData []byte `json:"value"`
+	Name  string `json:"name"`
+	Value []byte `json:"value"`
 }
 
 func NewConfigFilesK8sRepo(k8sDolittleRepo platformK8s.K8sRepo, k8sClient kubernetes.Interface, logContext logrus.FieldLogger) k8sRepo {
@@ -60,6 +62,10 @@ func (r k8sRepo) GetConfigFilesNamesList(applicationID string, environment strin
 		data = append(data, name)
 	}
 
+	for name := range configMap.Data {
+		data = append(data, name)
+	}
+
 	return data, nil
 }
 
@@ -80,6 +86,10 @@ func (r k8sRepo) AddEntryToConfigFiles(applicationID string, environment string,
 
 	configmapName := platformK8s.GetMicroserviceConfigFilesConfigmapName(name)
 	configMap, err := r.k8sDolittleRepo.GetConfigMap(applicationID, configmapName)
+	if err != nil {
+		logContext.WithField("error", err).Error("unable to load data from configmap")
+		return errors.New("unable to load data from configmap: " + err.Error())
+	}
 
 	if len(configMap.Data) == 0 {
 		configMap.Data = map[string]string{}
@@ -89,16 +99,16 @@ func (r k8sRepo) AddEntryToConfigFiles(applicationID string, environment string,
 		configMap.BinaryData = map[string][]byte{}
 	}
 
-	if err != nil {
-		logContext.WithField("error", err).Error("unable to load data from configmap")
-		return errors.New("unable to load data from configmap: " + err.Error())
+	if utf8.Valid(data.Value) {
+		configMap.Data[data.Name] = string(data.Value)
+	} else {
+		configMap.BinaryData[data.Name] = data.Value
+
 	}
 
 	// TODO would be nice to use a resource (application-namespace branch)
 	//r.k8sDolittleRepo.WriteConfigMap
 	// Update data
-
-	configMap.BinaryData[data.Name] = data.BinaryData
 
 	// Write configmap and secret
 	_, err = r.k8sDolittleRepo.WriteConfigMap(configMap)

--- a/pkg/platform/microservice/configFiles/repo.go
+++ b/pkg/platform/microservice/configFiles/repo.go
@@ -43,6 +43,7 @@ func (r k8sRepo) GetConfigFilesNamesList(applicationID string, environment strin
 		"microservice_id": microserviceID,
 		"environment":     environment,
 	})
+	logContext.Info("getting config files names list")
 
 	name, err := r.k8sDolittleRepo.GetMicroserviceName(applicationID, environment, microserviceID)
 	if err != nil {
@@ -65,6 +66,8 @@ func (r k8sRepo) GetConfigFilesNamesList(applicationID string, environment strin
 	for name := range configMap.Data {
 		data = append(data, name)
 	}
+
+	logContext.Infof("found %s config files", len(data))
 
 	return data, nil
 }

--- a/pkg/platform/microservice/configFiles/repo.go
+++ b/pkg/platform/microservice/configFiles/repo.go
@@ -70,7 +70,6 @@ func (r k8sRepo) GetConfigFilesNamesList(applicationID string, environment strin
 }
 
 func (r k8sRepo) AddEntryToConfigFiles(applicationID string, environment string, microserviceID string, data MicroserviceConfigFile) error {
-
 	// Get name of microservice
 	name, err := r.k8sDolittleRepo.GetMicroserviceName(applicationID, environment, microserviceID)
 	if err != nil {
@@ -105,10 +104,6 @@ func (r k8sRepo) AddEntryToConfigFiles(applicationID string, environment string,
 		configMap.BinaryData[data.Name] = data.Value
 
 	}
-
-	// TODO would be nice to use a resource (application-namespace branch)
-	//r.k8sDolittleRepo.WriteConfigMap
-	// Update data
 
 	// Write configmap and secret
 	_, err = r.k8sDolittleRepo.WriteConfigMap(configMap)

--- a/pkg/platform/microservice/configFiles/repo.go
+++ b/pkg/platform/microservice/configFiles/repo.go
@@ -67,7 +67,7 @@ func (r k8sRepo) GetConfigFilesNamesList(applicationID string, environment strin
 		data = append(data, name)
 	}
 
-	logContext.Infof("found %s config files", len(data))
+	logContext.Infof("found %d config files", len(data))
 
 	return data, nil
 }

--- a/pkg/platform/microservice/configFiles/repo_test.go
+++ b/pkg/platform/microservice/configFiles/repo_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Repo", func() {
 							Name: getAction.GetName(),
 						},
 						BinaryData: map[string][]byte{
-							binaryFile: []byte{0xff, 0xfe, 0xfd},
+							binaryFile: {0xff, 0xfe, 0xfd},
 						},
 						Data: map[string]string{
 							dataFile: "i just be data",

--- a/pkg/platform/microservice/configFiles/repo_test.go
+++ b/pkg/platform/microservice/configFiles/repo_test.go
@@ -1,0 +1,168 @@
+package configFiles_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	platformK8s "github.com/dolittle/platform-api/pkg/platform/k8s"
+	"github.com/sirupsen/logrus"
+	logrusTest "github.com/sirupsen/logrus/hooks/test"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/testing"
+
+	"github.com/dolittle/platform-api/pkg/platform/microservice/configFiles"
+)
+
+var _ = Describe("Repo", func() {
+
+	var (
+		repo configFiles.ConfigFilesRepo
+
+		clientSet *fake.Clientset
+		config    *rest.Config
+		k8sRepo   platformK8s.K8sRepo
+		// k8sRepoV2 k8s.Repo
+		logger         *logrus.Logger
+		applicationID  string
+		environment    string
+		microserviceID string
+	)
+
+	BeforeEach(func() {
+
+		clientSet = &fake.Clientset{}
+		config = &rest.Config{}
+		logger, _ = logrusTest.NewNullLogger()
+		k8sRepo = platformK8s.NewK8sRepo(clientSet, config, logger.WithField("context", "k8s-repo"))
+		// k8sRepoV2 = k8s.NewRepo(clientSet, logger.WithField("context", "k8s-repo-v2"))
+		repo = configFiles.NewConfigFilesK8sRepo(k8sRepo, clientSet, logger)
+		applicationID = "53fd6176-4a6b-4bb0-a32d-b18c69607e78"
+		environment = "test"
+		microserviceID = "963a5d70-8652-494a-a843-d3bebd660acb"
+
+		// have to mock this so that we can mock GetDeploymentsByEnvironmentWithMicroservice() from pkg/k8s/repo
+		// TODO have the platformK8s.NewK8sRepo take the k8sRepoV2 interface(s) as an argument so that we could mock it
+		// instead of having to go this deep in the chain
+		clientSet.AddReactor("list", "deployments", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+			filters := action.(testing.ListActionImpl).ListRestrictions
+			Expect(filters.Labels.Matches(labels.Set{
+				"tenant":       string(selection.Exists),
+				"environment":  environment,
+				"microservice": string(selection.Exists),
+				"application":  string(selection.Exists),
+			})).To(BeTrue())
+
+			deployment := &appsv1.DeploymentList{
+				Items: []appsv1.Deployment{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-deployment",
+							Labels: map[string]string{
+								"tenant":       "fake-tenant",
+								"application":  "fake-application",
+								"environment":  environment,
+								"microservice": "fake-microservice",
+							},
+							Annotations: map[string]string{
+								"dolittle.io/microservice-id": microserviceID,
+								"dolittle.io/application-id":  applicationID,
+							},
+						},
+					},
+				},
+			}
+
+			return true, deployment, nil
+		})
+	})
+
+	Describe("Adding a new entry", func() {
+		When("the incoming data is utf8", func() {
+			It("should save it to 'data' property", func() {
+				configFile := configFiles.MicroserviceConfigFile{
+					Name:  "utf8-valid-file.txt",
+					Value: []byte("𝝸м ᶏ ṕξꝛғȩçƭɬý 𝘀ɑᵮҿ ựⱦ𝐟8 ŝᴛгï𝖞𝓰 𝙣ө ᴨḗ𝑒ḑ 𝓽ⲟ ŵ𝞸ɾṙỳ ẃḩỵ àᵳḙ γ੦ǜ 𝓇𝕦ṇ𝜋𝙞𝖞ǵ 𝒸𝜎мξ ƀ⍺ć𝞳 𝛊 ѡợոṯ ḫṻɼ𝔱 ɏ𝗈ṵ"),
+				}
+
+				clientSet.AddReactor("update", "configmaps", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					updateAction := action.(testing.UpdateAction)
+					originalObj := updateAction.GetObject()
+					configMap := originalObj.(*corev1.ConfigMap)
+
+					Expect(configMap.Data[configFile.Name]).To(Equal(string(configFile.Value)))
+					Expect(configMap.BinaryData).To(BeEmpty())
+
+					return true, configMap, nil
+				})
+
+				err := repo.AddEntryToConfigFiles(applicationID, environment, microserviceID, configFile)
+
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("the incoming data is not utf8", func() {
+			It("should save it to 'binaryData' property", func() {
+				configFile := configFiles.MicroserviceConfigFile{
+					Name:  "not-utf8-valid-file.txt",
+					Value: []byte{0xff, 0xfe, 0xfd},
+				}
+
+				clientSet.AddReactor("update", "configmaps", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					updateAction := action.(testing.UpdateAction)
+					originalObj := updateAction.GetObject()
+					configMap := originalObj.(*corev1.ConfigMap)
+
+					Expect(configMap.BinaryData[configFile.Name]).To(Equal(configFile.Value))
+					Expect(configMap.Data).To(BeEmpty())
+
+					return true, configMap, nil
+				})
+
+				err := repo.AddEntryToConfigFiles(applicationID, environment, microserviceID, configFile)
+
+				Expect(err).To(BeNil())
+			})
+		})
+
+	})
+
+	Describe("getting config files names", func() {
+		When("the config map has both data and binary data", func() {
+			It("should return them both", func() {
+				binaryFile := "not-a-virus.mp4.mp3.zip.mov.exe"
+				dataFile := "just-data.txt"
+
+				clientSet.AddReactor("get", "configmaps", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					getAction := action.(testing.GetAction)
+					configMap := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: getAction.GetName(),
+						},
+						BinaryData: map[string][]byte{
+							binaryFile: []byte{0xff, 0xfe, 0xfd},
+						},
+						Data: map[string]string{
+							dataFile: "i just be data",
+						},
+					}
+					return true, configMap, nil
+				})
+
+				files, err := repo.GetConfigFilesNamesList(applicationID, environment, microserviceID)
+				Expect(err).To(BeNil())
+
+				Expect(files).ToNot(BeEmpty())
+				Expect(files).To(ConsistOf(binaryFile, dataFile))
+			})
+		})
+	})
+})

--- a/pkg/platform/microservice/configFiles/service.go
+++ b/pkg/platform/microservice/configFiles/service.go
@@ -42,20 +42,20 @@ func (s *service) GetConfigFilesNamesList(w http.ResponseWriter, r *http.Request
 		"microservice_id": microserviceID,
 		"environment":     environment,
 	})
-	
+
 	allowed := s.k8sDolittleRepo.CanModifyApplicationWithResponse(w, customerID, applicationID, userID)
 	if !allowed {
 		logContext.Info("UpdateConfigFiles: not allowed ")
 
 		return
 	}
-	
+
 	data, err := s.configFilesRepo.GetConfigFilesNamesList(applicationID, environment, microserviceID)
 	if err != nil {
 		utils.RespondWithError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	
+
 	response := platform.HttpResponseConfigFilesNamesList{
 		ApplicationID:  applicationID,
 		Environment:    environment,
@@ -75,7 +75,7 @@ func (s *service) UpdateConfigFiles(w http.ResponseWriter, r *http.Request) {
 
 	userID := r.Header.Get("User-ID")
 	customerID := r.Header.Get("Tenant-ID")
-	
+
 	logContext := s.logContext.WithFields(logrus.Fields{
 		"method":          "UpdateConfigFiles",
 		"application_id":  applicationID,
@@ -125,9 +125,8 @@ func (s *service) UpdateConfigFiles(w http.ResponseWriter, r *http.Request) {
 
 	s.logContext.Info("Update config files")
 
-	
 	body, err := ioutil.ReadAll(file)
-	
+
 	if err != nil {
 		msg := "UpdateConfigFiles ERROR: Invalid file"
 
@@ -137,9 +136,9 @@ func (s *service) UpdateConfigFiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer r.Body.Close()
-	
+
 	var input MicroserviceConfigFile
-	input.BinaryData = body
+	input.Value = body
 	input.Name = handler.Filename
 
 	err = s.configFilesRepo.AddEntryToConfigFiles(applicationID, environment, microserviceID, input)
@@ -166,7 +165,7 @@ func (s *service) DeleteConfigFile(w http.ResponseWriter, r *http.Request) {
 
 	userID := r.Header.Get("User-ID")
 	customerID := r.Header.Get("Tenant-ID")
-	
+
 	logContext := s.logContext.WithFields(logrus.Fields{
 		"method":          "DeleteConfigFile",
 		"application_id":  applicationID,
@@ -179,7 +178,7 @@ func (s *service) DeleteConfigFile(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		logContext.Info("DeleteConfigFile ERROR: Invalid request payload")
-		
+
 		utils.RespondWithError(w, http.StatusBadRequest, "Invalid request payload")
 		return
 	}


### PR DESCRIPTION
## Summary

- Fixes a bug with only the `binaryData` property for config files configmaps being used for fetching config files filenames.
- Adds support for both utf8 & non-utf8 files being uploaded as the configs. If the code detects that the incoming config file isn't valid utf8 it's going to get saved to the `binaryData` property. Otherwise it's saved to `data`.

## Reference
- https://app.asana.com/0/1202121266838773/1202244401000776