### PR TITLE
Fix `RemoveEntryFromConfigFiles()` method to delete from the data property too

### DIFF
--- a/pkg/platform/microservice/configFiles/repo.go
+++ b/pkg/platform/microservice/configFiles/repo.go
@@ -136,18 +136,13 @@ func (r k8sRepo) RemoveEntryFromConfigFiles(applicationID string, environment st
 
 	configmapName := platformK8s.GetMicroserviceConfigFilesConfigmapName(name)
 	configMap, err := r.k8sDolittleRepo.GetConfigMap(applicationID, configmapName)
-
 	if err != nil {
 		logContext.WithField("error", err).Error("unable to load data from configmap")
 		return err
 	}
 
-	if len(configMap.BinaryData) == 0 {
-		logContext.WithField("error", err).Error("no entries in configmap")
-		return err
-	}
-
 	delete(configMap.BinaryData, key)
+	delete(configMap.Data, key)
 
 	// Write configmap and secret
 	_, err = r.k8sDolittleRepo.WriteConfigMap(configMap)


### PR DESCRIPTION
## Summary

Fixes a bug with config files saved on the configmaps `data` property not being deleted in the `RemoveEntryFromConfigFiles()` method.

## Reference
- https://app.asana.com/0/1202121266838773/1202261003053932/f