### PR TITLE
Adding resource limits for head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ platform-api
 
 # Ignore test output
 profile.cov
+
+# Ignore IDE files 
+.idea

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/thoas/go-funk v0.9.0
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	github.com/zclconf/go-cty v1.9.1
-	go.mongodb.org/mongo-driver v1.7.0
+	go.mongodb.org/mongo-driver v1.9.1
 	golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558 // indirect

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,9 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.11.12 h1:famVnQVu7QwryBN4jNseQdUKES71ZAOnB6UQQJPZvqk=
 github.com/klauspost/compress v1.11.12/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
+github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -691,8 +692,6 @@ go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.mongodb.org/mongo-driver v1.3.0/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.mongodb.org/mongo-driver v1.3.4/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.mongodb.org/mongo-driver v1.4.2/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
-go.mongodb.org/mongo-driver v1.7.0 h1:hHrvOBWlWB2c7+8Gh/Xi5jj82AgidK/t7KVXBZ+IyUA=
-go.mongodb.org/mongo-driver v1.7.0/go.mod h1:Q4oFMbo1+MSNqICAdYMlC/zSTrwCogR4R8NzkI+yfU8=
 go.mongodb.org/mongo-driver v1.9.1 h1:m078y9v7sBItkt1aaoe2YlvWEXcD263e1a4E1fBrJ1c=
 go.mongodb.org/mongo-driver v1.9.1/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -716,10 +715,10 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
@@ -889,6 +888,7 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7 h1:8IVLkfbr2cLhv0a/vKq4UFUcJym8RmDoDboxCFWEjYE=
 golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/go.sum
+++ b/go.sum
@@ -693,6 +693,8 @@ go.mongodb.org/mongo-driver v1.3.4/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS
 go.mongodb.org/mongo-driver v1.4.2/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.mongodb.org/mongo-driver v1.7.0 h1:hHrvOBWlWB2c7+8Gh/Xi5jj82AgidK/t7KVXBZ+IyUA=
 go.mongodb.org/mongo-driver v1.7.0/go.mod h1:Q4oFMbo1+MSNqICAdYMlC/zSTrwCogR4R8NzkI+yfU8=
+go.mongodb.org/mongo-driver v1.9.1 h1:m078y9v7sBItkt1aaoe2YlvWEXcD263e1a4E1fBrJ1c=
+go.mongodb.org/mongo-driver v1.9.1/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/pkg/dolittle/k8s/deployment.go
+++ b/pkg/dolittle/k8s/deployment.go
@@ -49,18 +49,6 @@ func NewDeployment(microservice Microservice, headImage string, runtimeImage str
 	configEnvVariablesName = strings.ToLower(configEnvVariablesName)
 	configSecretEnvVariablesName = strings.ToLower(configSecretEnvVariablesName)
 
-	// TODO in the future, this could be linked to the customers subscription
-	// Or some way to let them override it as a premium feature
-	headResourceLimit, err := resource.ParseQuantity("500Mi")
-	if err != nil {
-		panic(err)
-	}
-
-	headResourceRequest, err := resource.ParseQuantity("250Mi")
-	if err != nil {
-		panic(err)
-	}
-
 	containers := []apiv1.Container{
 		{
 			Name:  "head",
@@ -72,14 +60,7 @@ func NewDeployment(microservice Microservice, headImage string, runtimeImage str
 					ContainerPort: 80,
 				},
 			},
-			Resources: apiv1.ResourceRequirements{
-				Limits: apiv1.ResourceList{
-					apiv1.ResourceMemory: headResourceLimit,
-				},
-				Requests: apiv1.ResourceList{
-					apiv1.ResourceMemory: headResourceRequest,
-				},
-			},
+			Resources: getHeadResources(microservice.Environment),
 			EnvFrom: []apiv1.EnvFromSource{
 				{
 					ConfigMapRef: &apiv1.ConfigMapEnvSource{
@@ -125,7 +106,7 @@ func NewDeployment(microservice Microservice, headImage string, runtimeImage str
 		},
 	}
 	if runtimeImage != "none" {
-		containers = append(containers, Runtime(runtimeImage))
+		containers = append(containers, Runtime(runtimeImage, microservice.Environment))
 	}
 
 	deployment := &appsv1.Deployment{
@@ -196,15 +177,7 @@ func NewDeployment(microservice Microservice, headImage string, runtimeImage str
 	return deployment
 }
 
-func Runtime(image string) apiv1.Container {
-	limit, err := resource.ParseQuantity("1Gi")
-	if err != nil {
-		panic(err)
-	}
-	request, err := resource.ParseQuantity("250Mi")
-	if err != nil {
-		panic(err)
-	}
+func Runtime(image, environment string) apiv1.Container {
 	return apiv1.Container{
 		Name:  "runtime",
 		Image: image,
@@ -220,14 +193,7 @@ func Runtime(image string) apiv1.Container {
 				ContainerPort: 9700,
 			},
 		},
-		Resources: apiv1.ResourceRequirements{
-			Limits: apiv1.ResourceList{
-				apiv1.ResourceMemory: limit,
-			},
-			Requests: apiv1.ResourceList{
-				apiv1.ResourceMemory: request,
-			},
-		},
+		Resources: getRuntimeResources(environment),
 		VolumeMounts: []apiv1.VolumeMount{
 			{
 				MountPath: "/app/.dolittle/tenants.json",
@@ -267,4 +233,62 @@ func Runtime(image string) apiv1.Container {
 		},
 	}
 }
+
 func int32Ptr(i int32) *int32 { return &i }
+
+// TODO in the future, this could be linked to the customers subscription
+// Or some way to let them override it as a premium feature
+
+func getHeadResources(environment string) apiv1.ResourceRequirements {
+	switch strings.ToLower(environment) {
+	case "prod":
+		return apiv1.ResourceRequirements{
+			Requests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("50m"),
+				apiv1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("2000m"),
+				apiv1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		}
+	default:
+		return apiv1.ResourceRequirements{
+			Requests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("25m"),
+				apiv1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("2000m"),
+				apiv1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		}
+	}
+}
+
+func getRuntimeResources(environment string) apiv1.ResourceRequirements {
+	switch strings.ToLower(environment) {
+	case "prod":
+		return apiv1.ResourceRequirements{
+			Requests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("50m"),
+				apiv1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("2000m"),
+				apiv1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		}
+	default:
+		return apiv1.ResourceRequirements{
+			Requests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("25m"),
+				apiv1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("2000m"),
+				apiv1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		}
+	}
+}

--- a/pkg/dolittle/k8s/deployment.go
+++ b/pkg/dolittle/k8s/deployment.go
@@ -49,6 +49,18 @@ func NewDeployment(microservice Microservice, headImage string, runtimeImage str
 	configEnvVariablesName = strings.ToLower(configEnvVariablesName)
 	configSecretEnvVariablesName = strings.ToLower(configSecretEnvVariablesName)
 
+	// TODO in the future, this could be linked to the customers subscription
+	// Or some way to let them override it as a premium feature
+	headResourceLimit, err := resource.ParseQuantity("500Mi")
+	if err != nil {
+		panic(err)
+	}
+
+	headResourceRequest, err := resource.ParseQuantity("250Mi")
+	if err != nil {
+		panic(err)
+	}
+
 	containers := []apiv1.Container{
 		{
 			Name:  "head",
@@ -58,6 +70,14 @@ func NewDeployment(microservice Microservice, headImage string, runtimeImage str
 					Name:          "http",
 					Protocol:      apiv1.ProtocolTCP,
 					ContainerPort: 80,
+				},
+			},
+			Resources: apiv1.ResourceRequirements{
+				Limits: apiv1.ResourceList{
+					apiv1.ResourceMemory: headResourceLimit,
+				},
+				Requests: apiv1.ResourceList{
+					apiv1.ResourceMemory: headResourceRequest,
 				},
 			},
 			EnvFrom: []apiv1.EnvFromSource{

--- a/pkg/dolittle/k8s/deployment_test.go
+++ b/pkg/dolittle/k8s/deployment_test.go
@@ -144,6 +144,12 @@ var _ = Describe("Deployment", func() {
 			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts[4].MountPath).To(Equal("/app/data"))
 			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name).To(Equal("config-files"))
 		})
+
+		It("should create a head container with resource limits", func() {
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("500Mi"))
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("250Mi"))
+		})
+
 		It("should create a container named 'runtime'", func() {
 			Expect(deployment.Spec.Template.Spec.Containers[1].Name).To(Equal("runtime"))
 		})
@@ -191,6 +197,12 @@ var _ = Describe("Deployment", func() {
 			Expect(deployment.Spec.Template.Spec.Containers[1].VolumeMounts[6].SubPath).To(Equal("appsettings.json"))
 			Expect(deployment.Spec.Template.Spec.Containers[1].VolumeMounts[6].Name).To(Equal("dolittle-config"))
 		})
+
+		It("should create a runtimer container with resource limits", func() {
+			Expect(deployment.Spec.Template.Spec.Containers[1].Resources.Limits.Memory().String()).To(Equal("1Gi"))
+			Expect(deployment.Spec.Template.Spec.Containers[1].Resources.Requests.Memory().String()).To(Equal("250Mi"))
+		})
+
 		It("should create a pod template with the 'tenants-config' volume", func() {
 			Expect(deployment.Spec.Template.Spec.Volumes[0].Name).To(Equal("tenants-config"))
 			Expect(deployment.Spec.Template.Spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name).To(Equal("andrejensen-tenants"))

--- a/pkg/dolittle/k8s/deployment_test.go
+++ b/pkg/dolittle/k8s/deployment_test.go
@@ -145,9 +145,11 @@ var _ = Describe("Deployment", func() {
 			Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts[4].Name).To(Equal("config-files"))
 		})
 
-		It("should create a head container with resource limits", func() {
-			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("500Mi"))
-			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("250Mi"))
+		It("should create a head container with resource requests and limits", func() {
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("25m"))
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("256Mi"))
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("2"))
+			Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("1Gi"))
 		})
 
 		It("should create a container named 'runtime'", func() {
@@ -198,9 +200,11 @@ var _ = Describe("Deployment", func() {
 			Expect(deployment.Spec.Template.Spec.Containers[1].VolumeMounts[6].Name).To(Equal("dolittle-config"))
 		})
 
-		It("should create a runtimer container with resource limits", func() {
+		It("should create a runtime container with resource limits", func() {
+			Expect(deployment.Spec.Template.Spec.Containers[1].Resources.Requests.Cpu().String()).To(Equal("25m"))
+			Expect(deployment.Spec.Template.Spec.Containers[1].Resources.Requests.Memory().String()).To(Equal("256Mi"))
+			Expect(deployment.Spec.Template.Spec.Containers[1].Resources.Limits.Cpu().String()).To(Equal("2"))
 			Expect(deployment.Spec.Template.Spec.Containers[1].Resources.Limits.Memory().String()).To(Equal("1Gi"))
-			Expect(deployment.Spec.Template.Spec.Containers[1].Resources.Requests.Memory().String()).To(Equal("250Mi"))
 		})
 
 		It("should create a pod template with the 'tenants-config' volume", func() {
@@ -217,16 +221,18 @@ var _ = Describe("Deployment", func() {
 		})
 	})
 
-	Describe("when creating a Runtime", func() {
+	Describe("when creating a Runtime for a Prod environment", func() {
 		var (
 			runtimeImage string
+			environment  string
 			container    corev1.Container
 		)
 
 		BeforeEach(func() {
 			runtimeImage = "dolittle/runtime:160.1.0"
+			environment = "Prod"
 
-			container = Runtime(runtimeImage)
+			container = Runtime(runtimeImage, environment)
 		})
 
 		It("should create a container named 'runtime'", func() {
@@ -283,6 +289,12 @@ var _ = Describe("Deployment", func() {
 			Expect(container.VolumeMounts[6].MountPath).To(Equal("/app/appsettings.json"))
 			Expect(container.VolumeMounts[6].SubPath).To(Equal("appsettings.json"))
 			Expect(container.VolumeMounts[6].Name).To(Equal("dolittle-config"))
+		})
+		It("should create a runtime container with resource limits", func() {
+			Expect(container.Resources.Requests.Cpu().String()).To(Equal("50m"))
+			Expect(container.Resources.Requests.Memory().String()).To(Equal("256Mi"))
+			Expect(container.Resources.Limits.Cpu().String()).To(Equal("2"))
+			Expect(container.Resources.Limits.Memory().String()).To(Equal("1Gi"))
 		})
 	})
 })

--- a/pkg/platform/application/k8s/resource_test.go
+++ b/pkg/platform/application/k8s/resource_test.go
@@ -81,6 +81,13 @@ var _ = Describe("Setting up an application", func() {
 			expect := `mongodump --host=todo-mongo.application-fake-application-123.svc.cluster.local:27017 --gzip --archive=/mnt/backup/fake-application-todo-$(date +%Y-%m-%d_%H-%M-%S).gz.mongodump`
 			Expect(resources.Cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args[0]).To(Equal(expect))
 		})
+
+		It("should have set resource requests and limits for the container in the StatefulSet", func() {
+			Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("50m"))
+			Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("512Mi"))
+			Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("2"))
+			Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2Gi"))
+		})
 	})
 	When("Creating the environment", func() {
 		var (

--- a/pkg/platform/application/k8s/resources.go
+++ b/pkg/platform/application/k8s/resources.go
@@ -15,6 +15,7 @@ import (
 
 	v1 "k8s.io/api/batch/v1"
 	v1beta1 "k8s.io/api/batch/v1beta1"
+	apiv1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -559,6 +560,7 @@ func NewMongo(environment string, tenant dolittleK8s.Tenant, application dolittl
 									MountPath: "/data/db",
 								},
 							},
+							Resources: getMongoResources(environment),
 						}}},
 				},
 				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
@@ -691,5 +693,31 @@ func NewLocalDevRoleBindingToDeveloper(tenant dolittleK8s.Tenant, application do
 			Kind:     "Role",
 			Name:     "developer",
 		},
+	}
+}
+func getMongoResources(environment string) apiv1.ResourceRequirements {
+	switch strings.ToLower(environment) {
+	case "prod":
+		return apiv1.ResourceRequirements{
+			Requests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("100m"),
+				apiv1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("2000m"),
+				apiv1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		}
+	default:
+		return apiv1.ResourceRequirements{
+			Requests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("50m"),
+				apiv1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("2000m"),
+				apiv1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Hard coding a default resource request and limit for CPU and Memory on:
- Head containers
- Runtime containers
- MongoDB containers (not backup jobs)

The requests are higher for "Prod" environments, according to the suggested default values:
```yaml
environments:
  prod:
    runtime:
      resources:
        requests:
          cpu: 50m
          memory: 256Mi
        limits:
          cpu: 2000m
          memory: 1Gi
    head:
      resources:
        requests:
          cpu: 50m
          memory: 256Mi
        limits:
          cpu: 2000m
          memory: 1Gi
    mongodb:
      resources:
        requests:
          cpu: 100m
          memory: 512Mi
        limits:
          cpu: 2000m
          memory: 2Gi

  non-prod:
    runtime:
      resources:
        requests:
          cpu: 25m
          memory: 256Mi
        limits:
          cpu: 2000m
          memory: 1Gi
    head:
      resources:
        requests:
          cpu: 25m
          memory: 256Mi
        limits:
          cpu: 2000m
          memory: 1Gi
    mongodb:
      resources:
        requests:
          cpu: 50m
          memory: 512Mi
        limits:
          cpu: 2000m
          memory: 2Gi

```