### PR TITLE
Add new deploy workflow to consolidate the steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy platform-api
+
+on:
+  workflow_call:
+    inputs:
+      namespace:
+        description: 'Namespace to deploy to'
+        required: true
+        type: string
+      deployment:
+        description: 'Name of the deployment in k8s'
+        required: true
+        type: string
+      image:
+        required: true
+        type: string
+      container:
+        description: 'Name of the container within the deployment, defaults to head'
+        required: false
+        default: head
+        type: string
+      configmap:
+        description: 'Name of the configmap in k8s'
+        required: true
+        type: string
+      configmap-field:
+        description: 'Name of the field within the configmaps data property'
+        required: true
+        type: string
+      configmap-value:
+        description: 'Value to set to the field'
+        required: true
+        type: string
+      environment:
+        description: 'GitHub environment to run the job on'
+        required: true
+        type: string
+    secrets:
+      K8S_CLUSTER_URL:
+        description: 'URL for the kubernetes cluster'
+        required: true
+      K8S_DEVOPS_SECRET:
+        description: |
+          The complete kubernetes secret object (YAML or JSON) for a serviceaccounts token.
+          The serviceaccount needs permissions to patch deployments & configmaps in the given namespace'
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Create patch JSON
+        id: patch-json
+        run: |
+          echo ::set-output name=patch_json::'{"data": { "${{ inputs.configmap-field }}": "${{ inputs.configmap-value }}" }}'
+        
+      - uses: azure/k8s-set-context@v2
+        with: 
+          method: service-account
+          k8s-url: ${{ secrets.K8S_CLUSTER_URL }}
+          k8s-secret: ${{ secrets.K8S_DEVOPS_SECRET }}
+      
+      - name: Update configmap env variable
+        run: |
+          kubectl -n ${{ inputs.namespace }} patch configmap ${{ inputs.configmap }} --type merge -p '${{ steps.patch-json.outputs.patch_json }}'
+      
+      - name: Update deployment image
+        run: |
+          kubectl -n ${{ inputs.namespace }} set image deployment/${{ inputs.deployment }} ${{ inputs.container }}=${{ inputs.image }}
+  

--- a/.github/workflows/release-and-deploy.yml
+++ b/.github/workflows/release-and-deploy.yml
@@ -82,7 +82,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
       - uses: actions/setup-go@v2
         with:
           go-version: "1.16.3"
@@ -129,52 +128,33 @@ jobs:
           version: ${{ needs.setup.outputs.next-version }}
           body: ${{ needs.setup.outputs.pr-body }}
 
-  update-jobs-environment-variable-dev:
-    needs: 
+  deploy-dev:
+    needs:
       - release
       - setup
-    uses: ./.github/workflows/update-configmap-field.yml
-    secrets: inherit
-    with:
-      environment: dev
-      namespace: system-api
-      name: dev-api-v1-env-variables
-      field: JOBS_OPERATIONS_IMAGE
-      value: dolittle/platform-operations:${{ needs.setup.outputs.next-version }}
-
-  deploy-dev:
-    needs: 
-      - setup
-      - update-jobs-environment-variable-dev
-    uses: ./.github/workflows/update-container-image.yml
+    uses: ./.github/workflows/deploy.yml
     secrets: inherit
     with:
       namespace: system-api
       deployment: dev-api-v1
       image: dolittle/platform-api:${{ needs.setup.outputs.next-version }}
+      configmap: dev-api-v1-env-variables
+      configmap-field: JOBS_OPERATIONS_IMAGE
+      configmap-value: dolittle/platform-operations:${{ needs.setup.outputs.next-version }}
       environment: dev
 
-  update-jobs-environment-variable-prod:
-    needs: 
+  deploy-prod:
+    needs:
       - release
       - setup
-    uses: ./.github/workflows/update-configmap-field.yml
-    secrets: inherit
-    with:
-      environment: prod
-      namespace: system-api
-      name: prod-api-v1-env-variables
-      field: JOBS_OPERATIONS_IMAGE
-      value: dolittle/platform-operations:${{ needs.setup.outputs.next-version }}
-    
-  deploy-prod:
-    needs: 
-      - setup
-      - update-jobs-environment-variable-prod
-    uses: ./.github/workflows/update-container-image.yml
+    uses: ./.github/workflows/deploy.yml
     secrets: inherit
     with:
       namespace: system-api
       deployment: prod-api-v1
       image: dolittle/platform-api:${{ needs.setup.outputs.next-version }}
+      configmap: prod-api-v1-env-variables
+      configmap-field: JOBS_OPERATIONS_IMAGE
+      configmap-value: dolittle/platform-operations:${{ needs.setup.outputs.next-version }}
       environment: prod
+    


### PR DESCRIPTION
## Summary

Simplify the deployment workflow so that it doesn't require 2 rounds of approvals. Due to the limitations of reusable workflows in GitHub we sadly can't use the other 2 reusable workflows to do this. Also forces a deployment.